### PR TITLE
Support files embedded within a JAR in CqlMigrate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,12 @@ task wrapper(type: Wrapper) {
     gradleVersion = '2.7'
 }
 
+configurations {
+    testCompileAndFunctional
+    functional.extendsFrom testCompileAndFunctional
+    testCompile.extendsFrom testCompileAndFunctional
+}
+
 dependencies {
     compile 'com.datastax.cassandra:cassandra-driver-core:2.1.8'
     compile 'org.slf4j:slf4j-api:1.7.12'
@@ -24,8 +30,10 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:2.0.0'
     testCompile 'org.scassandra:java-client:0.10.0'
-    testCompile 'org.cassandraunit:cassandra-unit-shaded:2.1.9.2'
     testCompile 'org.mockito:mockito-all:1.10.19'
+
+    testCompileAndFunctional 'org.cassandraunit:cassandra-unit-shaded:2.1.9.2'
+    functional 'org.slf4j:slf4j-simple:1.7.12'
 }
 
 task sourcesJar(type: Jar) {
@@ -43,3 +51,26 @@ artifacts {
     archives sourcesJar
     archives jar
 }
+
+task testJar (type: Jar) {
+    classifier = 'tests'
+    from (sourceSets.main.output, sourceSets.test.output)
+    from {
+        (configurations.runtime + configurations.functional).collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+    manifest {
+        attributes 'Main-Class': 'uk.sky.cqlmigrate.example.CmdLineEntryPoint'
+    }
+}
+
+// Functional test is to run the migrateSchema on a jar containing embedded CQL files and have it return successfully.
+task functional (dependsOn: ['testJar']) << {
+    exec {
+        executable = 'java'
+        args = ['-jar', testJar.archivePath, 'migrateSchema']
+    }
+}
+
+check.dependsOn(functional)

--- a/src/test/java/uk/sky/cqlmigrate/example/CmdLineEntryPoint.java
+++ b/src/test/java/uk/sky/cqlmigrate/example/CmdLineEntryPoint.java
@@ -1,0 +1,28 @@
+package uk.sky.cqlmigrate.example;
+
+public class CmdLineEntryPoint {
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+            CqlMigrateInvoker cqlMigrateInvoker = new CqlMigrateInvoker();
+
+            // @Before
+            CqlMigrateInvoker.setupCassandra();
+            cqlMigrateInvoker.setUp();
+
+            // Do the test
+            cqlMigrateInvoker.doMigrate();
+
+            // @After
+            cqlMigrateInvoker.tearDown();
+            CqlMigrateInvoker.tearDownCassandra();
+
+            System.exit(0);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}

--- a/src/test/java/uk/sky/cqlmigrate/example/CqlMigrateInvoker.java
+++ b/src/test/java/uk/sky/cqlmigrate/example/CqlMigrateInvoker.java
@@ -1,0 +1,70 @@
+package uk.sky.cqlmigrate.example;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.thrift.transport.TTransportException;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import uk.sky.cqlmigrate.CassandraLockConfig;
+import uk.sky.cqlmigrate.CqlMigrator;
+import uk.sky.cqlmigrate.CqlMigratorFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.time.Duration.ofMillis;
+
+public class CqlMigrateInvoker {
+
+    private static final String[] CASSANDRA_HOSTS = {"localhost"};
+    private static int binaryPort;
+    private static Cluster cluster;
+    private static Session session;
+    private static final String TEST_KEYSPACE = "cqlmigrate_test";
+
+    public void doMigrate() throws IOException, URISyntaxException {
+        CqlMigrator cqlMigrator = CqlMigratorFactory.create(CassandraLockConfig.builder().withTimeout(ofMillis(300)).build());
+
+        URL resource = this.getClass().getResource("");
+        try (FileSystem fs = FileSystems.newFileSystem(resource.toURI(), ImmutableMap.of("create", "true"))) {
+            List<Path> resourcePaths = Lists.newArrayList(fs.getPath("cql_bootstrap"));
+            cqlMigrator.migrate(CASSANDRA_HOSTS, binaryPort, TEST_KEYSPACE, resourcePaths);
+        }
+    }
+
+    public static void setupCassandra() throws ConfigurationException, IOException, TTransportException, InterruptedException {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE);
+        binaryPort = EmbeddedCassandraServerHelper.getNativeTransportPort();
+        cluster = Cluster.builder().addContactPoints(CASSANDRA_HOSTS).withPort(binaryPort).build();
+        session = cluster.connect();
+    }
+
+    public void setUp() throws Exception {
+        session.execute("DROP KEYSPACE IF EXISTS " + TEST_KEYSPACE);
+        session.execute("CREATE KEYSPACE IF NOT EXISTS cqlmigrate_locks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+        session.execute("CREATE TABLE IF NOT EXISTS cqlmigrate_locks.locks (name text PRIMARY KEY, client text)");
+    }
+
+    public void tearDown() {
+        session.execute("TRUNCATE cqlmigrate_locks.locks");
+        System.clearProperty("hosts");
+        System.clearProperty("keyspace");
+        System.clearProperty("directories");
+        session.execute("DROP KEYSPACE cqlmigrate_locks");
+    }
+
+    public static void tearDownCassandra() throws Exception {
+        cluster.close();
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+    }
+}


### PR DESCRIPTION
This is the first pass of a fix to https://github.com/sky-uk/cqlmigrate/issues/15.

The first two commits set up a failing functional test; the last is the actual code fix.

We have a few concerns with the current approach and would welcome feedback or input:
-  The func test consists of a JAR launched from Gradle.  A previous iteration (the first commit) had a jar launched from the command line within a Java integration test - arguably even more hokey.  Unfortunately we've not been able to get a repro by any means other than command-line invocation of the JAR (which to be fair does mirror how UMV uses CqlMigrate in reality right now).
-  We don't have setup or cleanup around the test - we did when it was in the Java integration test, so one option would be to go back towards that model.  As it stands, there's a dependency on the existence of the locks table with the lock for the `cqlmigrate_func_test` keyspace not being held.
-  (Related to above point) Currently the tests *work on my machine* :smiley: but they do have a hardcoded Cassandra address and port, so are failing on Travis...
-  Is there anything better we should be doing around the actual CQL files we're embedding in the JAR, or is what we have OK for now?