### PR TITLE
Add Gradle logic to allow release publication

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,20 @@
+# Releasing
+
+We use axion-release which relies on semantic versioning and git tags.
+
+To simply release a bug fix:
+
+    ./gradlew check release
+    ./gradlew publishArtifactPublicationToOpenSourceRepository
+
+To bump the version (when adding functionality or breaking backwards compatibility):
+
+    ./gradlew release -Prelease.forceVersion=1.0.0
+    ./gradlew publishArtifactPublicationToOpenSourceRepository
+
+Get the current version:
+
+    ./gradlew currentVersion
+
+Note that none of the above Gradle tasks will work correctly unless the relevant `openSource*` properties have been
+defined in the system gradle.properties.

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,49 @@ plugins {
     id 'java'
     id 'idea'
     id 'maven'
+    id 'maven-publish'
+    id 'pl.allegro.tech.build.axion-release' version '1.3.3'
+}
+
+scmVersion {
+    tag {
+        prefix = 'cqlmigrate'
+    }
 }
 
 group = 'uk.sky.cirrus'
+version = scmVersion.version
 sourceCompatibility = '1.8'
+
+if (!project.hasProperty("openSourceRepoUrl")) {
+    ext.openSourceRepoUrl = "dummy"
+}
+if (!project.hasProperty("openSourceRepoUser")) {
+    ext.openSourceRepoUser = "dummy"
+}
+if (!project.hasProperty("openSourceRepoPass")) {
+    ext.openSourceRepoPass = "dummy"
+}
+
+publishing {
+    repositories {
+        maven {
+            url openSourceRepoUrl
+            name 'openSource'
+
+            credentials {
+                username = openSourceRepoUser
+                password = openSourceRepoPass
+            }
+        }
+    }
+    publications {
+        artifacts(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+        }
+    }
+}
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,0 @@
-#Thu, 23 Jul 2015 16:34:39 +0100
-version=0.8-SNAPSHOT


### PR DESCRIPTION
Note that `gradle.properties` config on the build machine is required to provide the URL, username and password for an actual release.