### PR TITLE
Correct read/write consistency levels which were the wrong way round

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'org.mockito:mockito-core:1.10.19'
 
-    testCompile 'org.scassandra:java-client:1.0.0'
+    testCompile 'org.scassandra:java-client:1.0.3'
 
     testCompileAndFunctional 'org.cassandraunit:cassandra-unit-shaded:2.1.9.2'
     functional 'org.slf4j:slf4j-simple:1.7.12'

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorFactory.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorFactory.java
@@ -13,8 +13,8 @@ public class CqlMigratorFactory {
     public static CqlMigrator create(CassandraLockConfig lockConfig) {
         return new CqlMigratorImpl(CqlMigratorConfig.builder()
                 .withCassandraLockConfig(lockConfig)
-                .withReadConsistencyLevel(ConsistencyLevel.ALL)
-                .withWriteConsistencyLevel(ConsistencyLevel.LOCAL_ONE)
+                .withReadConsistencyLevel(ConsistencyLevel.LOCAL_ONE)
+                .withWriteConsistencyLevel(ConsistencyLevel.ALL)
                 .build());
     }
 }

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
@@ -44,13 +44,7 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
             .withClientId(CLIENT_ID)
             .build();
 
-    private final CqlMigratorImpl migrator = new CqlMigratorImpl(
-            CqlMigratorConfig.builder()
-                    .withCassandraLockConfig(lockConfig)
-                    .withReadConsistencyLevel(EXPECTED_READ_CONSISTENCY_LEVEL)
-                    .withWriteConsistencyLevel(EXPECTED_WRITE_CONSISTENCY_LEVEL)
-                    .build()
-    );
+    private final CqlMigrator migrator = CqlMigratorFactory.create(lockConfig);
 
     private PrimingClient primingClient = scassandra.primingClient();
     private ActivityClient activityClient = scassandra.activityClient();


### PR DESCRIPTION
In #24 we discussed at length setting:
-  *write* consistency to **ALL**
-  *read* consistency to **LOCAL_ONE**

Unfortunately, in the actual implementation we got this the wrong way round, and our tests tested themselves rather than the production code.

This PR aims to fix that.  I changed the tests so they started failing, and then changed the prod code so the tests went green again.

After this goes in we will need to issue another release.