### PR TITLE
issue:35 make cluster health check optional

### DIFF
--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorConfig.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorConfig.java
@@ -1,17 +1,20 @@
 package uk.sky.cqlmigrate;
 
 import com.datastax.driver.core.ConsistencyLevel;
-import static com.google.common.base.Preconditions.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class CqlMigratorConfig {
     private final CassandraLockConfig cassandraLockConfig;
     private final ConsistencyLevel readConsistencyLevel;
     private final ConsistencyLevel writeConsistencyLevel;
+    private final boolean checkAllNodesHealthy;
 
-    private CqlMigratorConfig(CassandraLockConfig cassandraLockConfig, ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel) {
+    private CqlMigratorConfig(CassandraLockConfig cassandraLockConfig, ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel, boolean checkAllNodesHealthy) {
         this.cassandraLockConfig = checkNotNull(cassandraLockConfig);
         this.readConsistencyLevel = checkNotNull(readConsistencyLevel);
         this.writeConsistencyLevel = checkNotNull(writeConsistencyLevel);
+        this.checkAllNodesHealthy = checkAllNodesHealthy;
     }
 
     public static CassandraConfigBuilder builder() {
@@ -30,11 +33,16 @@ public class CqlMigratorConfig {
         return writeConsistencyLevel;
     }
 
+    public boolean checkAllNodesHealthy() {
+        return checkAllNodesHealthy;
+    }
+
     public static class CassandraConfigBuilder {
 
         private CassandraLockConfig cassandraLockConfig;
         private ConsistencyLevel readConsistencyLevel;
         private ConsistencyLevel writeConsistencyLevel;
+        private boolean checkAllNodesHealthy = true;
 
         private CassandraConfigBuilder() {}
 
@@ -53,8 +61,13 @@ public class CqlMigratorConfig {
             return this;
         }
 
+        public CassandraConfigBuilder withCheckAllNodesHealthy(boolean checkAllNodesHealthy) {
+            this.checkAllNodesHealthy = checkAllNodesHealthy;
+            return this;
+        }
+
         public CqlMigratorConfig build() {
-            return new CqlMigratorConfig(cassandraLockConfig, readConsistencyLevel, writeConsistencyLevel);
+            return new CqlMigratorConfig(cassandraLockConfig, readConsistencyLevel, writeConsistencyLevel, checkAllNodesHealthy);
         }
     }
 }

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
@@ -67,9 +67,13 @@ final class CqlMigratorImpl implements CqlMigrator {
      * {@inheritDoc}
      */
     public void migrate(Session session, String keyspace, Collection<Path> directories) {
-        Cluster cluster = session.getCluster();
-        ClusterHealth clusterHealth = new ClusterHealth(cluster);
-        clusterHealth.check();
+        if(cqlMigratorConfig.checkAllNodesHealthy()) {
+            LOGGER.info("Performing cluster health check.");
+            Cluster cluster = session.getCluster();
+            ClusterHealth clusterHealth = new ClusterHealth(cluster);
+            clusterHealth.check();
+            LOGGER.info("All nodes in cluster are reporting they are up.");
+        }
 
         CassandraLockingMechanism cassandraLockingMechanism = new CassandraLockingMechanism(session, keyspace);
         Lock lock = new Lock(cassandraLockingMechanism, cqlMigratorConfig.getCassandraLockConfig());

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorCassandraHealthCheckTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorCassandraHealthCheckTest.java
@@ -1,0 +1,98 @@
+package uk.sky.cqlmigrate;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Session;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CassandraClusterFactory.class, CqlMigratorImpl.class})
+public class CqlMigratorCassandraHealthCheckTest {
+
+    private static final String[] HOSTS = {"host167"};
+    private static final int PORT = 7434;
+    private static final String USERNAME = "user126";
+    private static final String PASSWORD = "pass684";
+
+    @Mock
+    private CassandraClusterFactory clusterFactory;
+    @Mock
+    private Cluster cluster;
+    @Mock
+    private Session session;
+    @Mock
+    private ClusterHealth clusterHealthMock;
+
+    @Before
+    public void setUp() throws Exception {
+        mockStatic(CassandraClusterFactory.class);
+        when(CassandraClusterFactory.createCluster(HOSTS, PORT, USERNAME, PASSWORD)).thenReturn(cluster);
+        when(cluster.connect()).thenReturn(session);
+        when(session.getCluster()).thenReturn(cluster);
+
+        PowerMockito.whenNew(ClusterHealth.class).withAnyArguments().thenReturn(clusterHealthMock);
+        PowerMockito.whenNew(CassandraLockingMechanism.class).withAnyArguments().thenThrow(new SuspendCodeExecutionException("Provided to suspend code execution for the testcase."));
+    }
+
+    @Test
+    public void shouldCheckClusterHealthWhenConfigIsOn() throws Exception {
+        // given
+        boolean checkAllNodesHealthy = true;
+
+        CqlMigratorConfig config = getCqlMigratorConfig(checkAllNodesHealthy);
+        CqlMigratorImpl cqlMigrator = new CqlMigratorImpl(config);
+        // when
+        try {
+            cqlMigrator.migrate(HOSTS, PORT, USERNAME, PASSWORD, null, Collections.emptyList());
+        } catch (SuspendCodeExecutionException e) {
+            // expected from PowerMock
+        }
+        //then
+        verify(clusterHealthMock).check();
+    }
+
+    @Test
+    public void shouldNotCheckClusterHealthWhenConfigIsOff() throws Exception {
+        // given
+        boolean checkAllNodesHealthy = false;
+
+        CqlMigratorConfig config = getCqlMigratorConfig(checkAllNodesHealthy);
+        CqlMigratorImpl cqlMigrator = new CqlMigratorImpl(config);
+        // when
+        try {
+            cqlMigrator.migrate(HOSTS, PORT, USERNAME, PASSWORD, null, Collections.emptyList());
+        } catch (SuspendCodeExecutionException e) {
+            // expected from PowerMock
+        }
+        //then
+        verify(clusterHealthMock, never()).check();
+    }
+
+    private CqlMigratorConfig getCqlMigratorConfig(boolean checkAllNodesHealthy) {
+        return CqlMigratorConfig.builder()
+                .withReadConsistencyLevel(ConsistencyLevel.ONE)
+                .withWriteConsistencyLevel(ConsistencyLevel.TWO)
+                .withCassandraLockConfig(CassandraLockConfig.builder().build())
+                .withCheckAllNodesHealthy(checkAllNodesHealthy)
+                .build();
+    }
+
+    private static class SuspendCodeExecutionException extends RuntimeException {
+        public SuspendCodeExecutionException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorConfigTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorConfigTest.java
@@ -28,7 +28,7 @@ public class CqlMigratorConfigTest {
     public static CassandraLockConfig CASSANDRA_LOCK_CONFIG_BAD = null;
 
     @Theory
-    public void shouldThrowIllegalArgumentExceptionWhenAnyParameterPassedIntoBuilderIsNull(CassandraLockConfig config, ConsistencyLevel readCL, ConsistencyLevel writeCL) {
+    public void shouldThrowNullPointerExceptionWhenAnyParameterPassedIntoBuilderIsNull(CassandraLockConfig config, ConsistencyLevel readCL, ConsistencyLevel writeCL) {
         Assume.assumeTrue(config == null || readCL == null || writeCL == null);
 
         expectedException.expect(NullPointerException.class);


### PR DESCRIPTION
At the moment cqlmigrate requires that all nodes in all datacentres are up before it will run. We would like to make this check optional so that it will still run if a node is down so that the migration will be attempted with the supplied consistency level - which we will plan to set to LOCAL_QUORUM for read and EACH_QUORUM for write for our migrations.