### PR TITLE
Don't check cluster health when there are no schema changes.

### DIFF
--- a/src/main/java/uk/sky/cqlmigrate/CqlLoader.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlLoader.java
@@ -14,6 +14,9 @@ class CqlLoader {
     private CqlLoader() {}
 
     static void load(SessionContext sessionContext, List<String> cqlStatements) {
+        if (!cqlStatements.isEmpty()) {
+            sessionContext.checkClusterHealth();
+        }
         try {
             cqlStatements.stream()
                     .map(stringStatement -> new SimpleStatement(stringStatement).setConsistencyLevel(sessionContext.getWriteConsistencyLevel()))

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorFactory.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorFactory.java
@@ -27,6 +27,6 @@ public class CqlMigratorFactory {
      * @since 0.9.4
      */
     public static CqlMigrator create(CqlMigratorConfig cqlMigratorConfig) {
-        return new CqlMigratorImpl(cqlMigratorConfig);
+        return new CqlMigratorImpl(cqlMigratorConfig, new SessionContextFactory());
     }
 }

--- a/src/main/java/uk/sky/cqlmigrate/SessionContext.java
+++ b/src/main/java/uk/sky/cqlmigrate/SessionContext.java
@@ -8,11 +8,14 @@ class SessionContext {
     private final Session session;
     private final ConsistencyLevel readConsistencyLevel;
     private final ConsistencyLevel writeConsistencyLevel;
+    private final ClusterHealth clusterHealth;
+    private boolean clusterHealthChecked = false;
 
-    SessionContext(Session session, ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel) {
+    SessionContext(Session session, ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel, ClusterHealth clusterHealth) {
         this.session = session;
         this.readConsistencyLevel = readConsistencyLevel;
         this.writeConsistencyLevel = writeConsistencyLevel;
+        this.clusterHealth = clusterHealth;
     }
 
     public Session getSession() {
@@ -25,5 +28,12 @@ class SessionContext {
 
     public ConsistencyLevel getWriteConsistencyLevel() {
         return writeConsistencyLevel;
+    }
+
+    public void checkClusterHealth() {
+        if (!clusterHealthChecked) {
+            clusterHealth.check();
+            clusterHealthChecked = true;
+        }
     }
 }

--- a/src/main/java/uk/sky/cqlmigrate/SessionContextFactory.java
+++ b/src/main/java/uk/sky/cqlmigrate/SessionContextFactory.java
@@ -1,0 +1,10 @@
+package uk.sky.cqlmigrate;
+
+import com.datastax.driver.core.Session;
+
+class SessionContextFactory {
+    SessionContext getInstance(Session session, CqlMigratorConfig cqlMigratorConfig) {
+        ClusterHealth clusterHealth = new ClusterHealth(session.getCluster());
+        return new SessionContext(session, cqlMigratorConfig.getReadConsistencyLevel(), cqlMigratorConfig.getWriteConsistencyLevel(), clusterHealth);
+    }
+}

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorHealthCheckTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorHealthCheckTest.java
@@ -1,0 +1,152 @@
+package uk.sky.cqlmigrate;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.thrift.transport.TTransportException;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.*;
+
+public class CqlMigratorHealthCheckTest {
+    private static final String[] CASSANDRA_HOSTS = {"localhost"};
+    private static String username = "cassandra";
+    private static String password = "cassandra";
+    private static int binaryPort;
+    private static Cluster cluster;
+    private static Session session;
+    private static final String TEST_KEYSPACE = "cqlmigrate_clusterhealth_test";
+
+    private ClusterHealth mockClusterHealth = mock(ClusterHealth.class);
+    private final SessionContextFactory sessionContextFactory = new SessionContextFactory() {
+        @Override
+        SessionContext getInstance(Session session, CqlMigratorConfig cqlMigratorConfig) {
+            return new SessionContext(session, cqlMigratorConfig.getReadConsistencyLevel(), cqlMigratorConfig.getWriteConsistencyLevel(), mockClusterHealth);
+        }
+    };
+
+    private final CqlMigratorImpl migrator = new CqlMigratorImpl(CqlMigratorConfig.builder()
+            .withCassandraLockConfig(CassandraLockConfig.builder().build())
+            .withReadConsistencyLevel(ConsistencyLevel.ALL)
+            .withWriteConsistencyLevel(ConsistencyLevel.ALL)
+            .build(), sessionContextFactory);
+
+    @BeforeClass
+    public static void setupCassandra() throws ConfigurationException, IOException, TTransportException, InterruptedException {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE);
+        binaryPort = EmbeddedCassandraServerHelper.getNativeTransportPort();
+
+        cluster = Cluster.builder()
+                .addContactPoints(CASSANDRA_HOSTS)
+                .withPort(binaryPort)
+                .withCredentials(username, password)
+                .build();
+        session = cluster.connect();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        session.execute("DROP KEYSPACE IF EXISTS cqlmigrate_clusterhealth_test");
+        session.execute("CREATE KEYSPACE IF NOT EXISTS cqlmigrate WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+        session.execute("CREATE TABLE IF NOT EXISTS cqlmigrate.locks (name text PRIMARY KEY, client text)");
+    }
+
+    @After
+    public void tearDown() {
+        session.execute("TRUNCATE cqlmigrate.locks");
+        System.clearProperty("hosts");
+        System.clearProperty("keyspace");
+        System.clearProperty("directories");
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        session.execute("DROP KEYSPACE cqlmigrate");
+        cluster.close();
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+    }
+
+    private Path getResourcePath(String resourcePath) throws URISyntaxException {
+        return Paths.get(ClassLoader.getSystemResource(resourcePath).toURI());
+    }
+
+    @Test
+    public void checkClusterHealthCheckedWhenBootstrappingCassandra() throws Exception {
+        //given
+        Collection<Path> cqlPaths = singletonList(getResourcePath("cql_cluster_health_bootstrap"));
+        //when
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+
+        //then
+        verify(mockClusterHealth, times(1)).check();
+    }
+
+    @Test
+    public void checkClusterHealthCheckedWhenCreatingSchemaMigrateTable() throws Exception {
+        //given
+        session.execute("CREATE KEYSPACE cqlmigrate_clusterhealth_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+        Collection<Path> cqlPaths = singletonList(getResourcePath("cql_cluster_health_bootstrap"));
+        //when
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+
+        //then
+        verify(mockClusterHealth, times(1)).check();
+    }
+
+    @Test
+    public void checkClusterHealthCheckedWhenThereAreChanges() throws Exception {
+        //given
+        Collection<Path> cqlPaths = new ArrayList<>();
+        cqlPaths.add(getResourcePath("cql_cluster_health_bootstrap"));
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+        cqlPaths.add(getResourcePath("cql_cluster_health_first"));
+        Mockito.reset(mockClusterHealth);
+        //when
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+        //then
+        verify(mockClusterHealth, times(1)).check();
+    }
+
+    @Test
+    public void checkClusterHealthCheckedWhenThereAreFollowingChanges() throws Exception {
+        //given
+        Collection<Path> cqlPaths = Lists.newArrayList(getResourcePath("cql_cluster_health_bootstrap"), getResourcePath("cql_cluster_health_first"));
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+        Mockito.reset(mockClusterHealth);
+        cqlPaths.add(getResourcePath("cql_cluster_health_second"));
+        //when
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+        //then
+        verify(mockClusterHealth, times(1)).check();
+    }
+
+    @Test
+    public void checkClusterHealthNotCheckedWhenThereAreNoChanges() throws Exception {
+        Collection<Path> cqlPaths = Lists.newArrayList(getResourcePath("cql_cluster_health_bootstrap"), getResourcePath("cql_cluster_health_first"));
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+        Mockito.reset(mockClusterHealth);
+        //when
+        migrator.migrate(CASSANDRA_HOSTS, binaryPort, username, password, TEST_KEYSPACE, cqlPaths);
+        //then
+        verify(mockClusterHealth, never()).check();
+    }
+}

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorImplTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorImplTest.java
@@ -37,7 +37,7 @@ public class CqlMigratorImplTest {
             .withCassandraLockConfig(CassandraLockConfig.builder().build())
             .withReadConsistencyLevel(ConsistencyLevel.ALL)
             .withWriteConsistencyLevel(ConsistencyLevel.ALL)
-            .build());
+            .build(), new SessionContextFactory());
 
     private ExecutorService executorService;
 
@@ -102,7 +102,7 @@ public class CqlMigratorImplTest {
                 .withCassandraLockConfig(CassandraLockConfig.builder().withPollingInterval(ofMillis(50)).withTimeout(ofMillis(300)).build())
                 .withReadConsistencyLevel(ConsistencyLevel.ALL)
                 .withWriteConsistencyLevel(ConsistencyLevel.ALL)
-                .build());
+                .build(), new SessionContextFactory());
 
         String client = UUID.randomUUID().toString();
         session.execute("INSERT INTO cqlmigrate.locks (name, client) VALUES (?, ?)", LOCK_NAME, client);

--- a/src/test/java/uk/sky/cqlmigrate/SchemaUpdatesTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/SchemaUpdatesTest.java
@@ -20,14 +20,16 @@ import static org.assertj.core.api.Assertions.fail;
 public class SchemaUpdatesTest {
 
     private static final String[] CASSANDRA_HOSTS = {"localhost"};
+    private static final String TEST_KEYSPACE = "cqlmigrate_test";
+    private static final String SCHEMA_UPDATES_TABLE = "schema_updates";
+
     private static int binaryPort;
     private static String username = "cassandra";
     private static String password = "cassandra";
     private static Cluster cluster;
     private static Session session;
-    private static final String TEST_KEYSPACE = "cqlmigrate_test";
+    private static ClusterHealth clusterHealth;
 
-    private static final String SCHEMA_UPDATES_TABLE = "schema_updates";
 
     @BeforeClass
     public static void setupCassandra() throws ConfigurationException, IOException, TTransportException, InterruptedException {
@@ -35,6 +37,7 @@ public class SchemaUpdatesTest {
         binaryPort = EmbeddedCassandraServerHelper.getNativeTransportPort();
 
         cluster = Cluster.builder().addContactPoints(CASSANDRA_HOSTS).withPort(binaryPort).withCredentials(username, password).build();
+        clusterHealth = new ClusterHealth(cluster);
         session = cluster.connect();
     }
 
@@ -62,7 +65,7 @@ public class SchemaUpdatesTest {
         //given
         cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
         Session session = cluster.connect(TEST_KEYSPACE);
-        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL);
+        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
         SchemaUpdates schemaUpdates = new SchemaUpdates(sessionContext, TEST_KEYSPACE);
 
         //when
@@ -78,7 +81,7 @@ public class SchemaUpdatesTest {
         //given
         cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
         Session session = cluster.connect(TEST_KEYSPACE);
-        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL);
+        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
         SchemaUpdates schemaUpdates = new SchemaUpdates(sessionContext, TEST_KEYSPACE);
 
         //when

--- a/src/test/java/uk/sky/cqlmigrate/SessionContextTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/SessionContextTest.java
@@ -1,0 +1,49 @@
+package uk.sky.cqlmigrate;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Session;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionContextTest {
+
+    private SessionContext sessionContext;
+
+    @Mock
+    private Session session;
+    @Mock
+    private Cluster cluster;
+    @Mock
+    private ClusterHealth mockedClusterHealth;
+
+    @Before
+    public void setUp() throws Exception {
+        Mockito.when(session.getCluster()).thenReturn(cluster);
+        sessionContext = new SessionContext(session, ConsistencyLevel.ONE, ConsistencyLevel.TWO, mockedClusterHealth);
+    }
+
+
+    @Test
+    public void shouldCallClusterHealth() throws Exception {
+        // when
+        sessionContext.checkClusterHealth();
+        // then
+        Mockito.verify(mockedClusterHealth, Mockito.times(1)).check();
+    }
+
+    @Test
+    public void shouldCallClusterHealthOnlyOnce() throws Exception {
+        // given
+        sessionContext.checkClusterHealth();
+        // when
+        sessionContext.checkClusterHealth();
+        // then
+        Mockito.verify(mockedClusterHealth, Mockito.times(1)).check();
+    }
+}

--- a/src/test/resources/cql_cluster_health_bootstrap/bootstrap.cql
+++ b/src/test/resources/cql_cluster_health_bootstrap/bootstrap.cql
@@ -1,0 +1,2 @@
+CREATE KEYSPACE cqlmigrate_clusterhealth_test
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };

--- a/src/test/resources/cql_cluster_health_first/2016-08-24-13:14-first.cql
+++ b/src/test/resources/cql_cluster_health_first/2016-08-24-13:14-first.cql
@@ -1,0 +1,1 @@
+CREATE TABLE first (name text primary key);

--- a/src/test/resources/cql_cluster_health_second/2016-08-24-13:15-second.cql
+++ b/src/test/resources/cql_cluster_health_second/2016-08-24-13:15-second.cql
@@ -1,0 +1,1 @@
+CREATE TABLE second (name text primary key);


### PR DESCRIPTION
The change we propose is to only require that all nodes are up if cqlmigrate needs to make any changes at all i.e. creating the keyspace, creating the schema migration table and any application specific migrations that have not been applied (determined by querying schema_migrations table)

At the point we determine that a change is needed, the ClusterHealth.check() would be invoked and if this fails the cqlmigrate would abort.

These are the changes agreed in https://github.com/sky-uk/cqlmigrate/pull/36