### PR TITLE
Remove the ability to set custom client id in CassandraLockConfig. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+classes/
 build/
 target/
 cqlmigrate.iws

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ To apply all `.cql` files located in `/cql` in the classpath:
 CassandraLockConfig lockConfig = CassandraLockConfig.builder()
         .withTimeout(Duration.standardSeconds(3))
         .withPollingInterval(Duration.millis(500))
-        .withClientId("node-uuid")
         .build())
 
 // Create a migrator and run it

--- a/src/main/java/uk/sky/cqlmigrate/CassandraLockConfig.java
+++ b/src/main/java/uk/sky/cqlmigrate/CassandraLockConfig.java
@@ -28,12 +28,6 @@ public class CassandraLockConfig extends LockConfig {
             return this;
         }
 
-        @Override
-        public CassandraLockConfigBuilder withClientId(String clientId) {
-            super.withClientId(clientId);
-            return this;
-        }
-
         public CassandraLockConfig build() {
             return new CassandraLockConfig(pollingInterval, timeout, clientId);
         }

--- a/src/main/java/uk/sky/cqlmigrate/LockConfig.java
+++ b/src/main/java/uk/sky/cqlmigrate/LockConfig.java
@@ -68,17 +68,6 @@ public class LockConfig {
             return this;
         }
 
-        /**
-         * Client id to use to identify lock holder
-         *
-         * @param clientId defaults to a UUID
-         * @return this
-         */
-        public LockConfigBuilder withClientId(String clientId) {
-            this.clientId = clientId;
-            return this;
-        }
-
         public LockConfig build() {
             return new LockConfig(pollingInterval, timeout, clientId);
         }

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
@@ -6,11 +6,7 @@ import com.datastax.driver.core.Session;
 import com.google.common.collect.ImmutableMap;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.thrift.transport.TTransportException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.scassandra.cql.PrimitiveType;
 import org.scassandra.http.client.ActivityClient;
 import org.scassandra.http.client.PrimingClient;
@@ -23,12 +19,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.UUID;
 
 import static java.util.Arrays.asList;
-import static org.scassandra.http.client.PrimingRequest.preparedStatementBuilder;
-import static org.scassandra.http.client.PrimingRequest.queryBuilder;
-import static org.scassandra.http.client.PrimingRequest.then;
+import static org.scassandra.http.client.PrimingRequest.*;
 import static org.scassandra.http.client.types.ColumnMetadata.column;
 import static org.scassandra.matchers.Matchers.containsQuery;
 
@@ -41,11 +34,9 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
     private static String username = "cassandra";
     private static String password = "cassandra";
     public static final int FREE_PORT = PortScavenger.getFreePort();
-    private static final String CLIENT_ID = UUID.randomUUID().toString();
     private static final String TEST_KEYSPACE = "cqlmigrate_test";
 
     private final CassandraLockConfig lockConfig = CassandraLockConfig.builder()
-            .withClientId(CLIENT_ID)
             .build();
 
 
@@ -80,7 +71,7 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
                         then()
                                 .withVariableTypes(PrimitiveType.TEXT, PrimitiveType.TEXT)
                                 .withColumnTypes(column("client", PrimitiveType.TEXT), column("[applied]", PrimitiveType.BOOLEAN))
-                                .withRows(ImmutableMap.of("client", CLIENT_ID, "[applied]", true)))
+                                .withRows(ImmutableMap.of("client", lockConfig.getClientId(), "[applied]", true)))
         );
 
         primingClient.prime(preparedStatementBuilder()
@@ -89,7 +80,7 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
                         then()
                                 .withVariableTypes(PrimitiveType.TEXT, PrimitiveType.TEXT)
                                 .withColumnTypes(column("client", PrimitiveType.TEXT), column("[applied]", PrimitiveType.BOOLEAN))
-                                .withRows(ImmutableMap.of("client", CLIENT_ID, "[applied]", true)))
+                                .withRows(ImmutableMap.of("client", lockConfig.getClientId(), "[applied]", true)))
         );
     }
 

--- a/src/test/java/uk/sky/cqlmigrate/LockVerificationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/LockVerificationTest.java
@@ -8,7 +8,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.sky.cqlmigrate.CassandraLockConfig.CassandraLockConfigBuilder;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -39,13 +38,9 @@ public class LockVerificationTest {
 
     private Cluster cluster;
     private Session session;
-    private CassandraLockConfigBuilder configBuilder;
 
     @Before
     public void setUp() {
-        configBuilder = CassandraLockConfig.builder()
-                .withPollingInterval(Duration.ofMillis(30));
-
         cluster = createCluster();
         session = cluster.connect();
 
@@ -118,7 +113,7 @@ public class LockVerificationTest {
             Session session = cluster.connect();
 
             CassandraLockingMechanism lockingMechanism = new CassandraLockingMechanism(session, KEYSPACE);
-            CassandraLockConfig lockConfig = configBuilder.withClientId(UUID.randomUUID().toString()).build();
+            CassandraLockConfig lockConfig = createCassandraLockConfig();
 
             Lock lock = new Lock(lockingMechanism, lockConfig);
 
@@ -195,6 +190,11 @@ public class LockVerificationTest {
                 .withQueryOptions(queryOptions)
                 .withSocketOptions(socketOptions)
                 .build();
+    }
+
+    private CassandraLockConfig createCassandraLockConfig() {
+        return CassandraLockConfig.builder()
+                .withPollingInterval(Duration.ofMillis(30)).build();
     }
 
 }


### PR DESCRIPTION
Use default generated random client id. Fixes #43. 