### PR TITLE
Parse cql files with code comments

### DIFF
--- a/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
@@ -30,4 +30,18 @@ public class CqlFileParserTest {
         assertThat(cqlStatements, hasSize(1));
         assertThat(cqlStatements.get(0), equalToIgnoringWhiteSpace(expectedStatement));
     }
+
+    @Test
+    public void shouldRemoveComments() throws Exception {
+        //given
+        Path cqlPath = getResourcePath("cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql");
+
+        //when
+        List<String> cqlStatements = CqlFileParser.getCqlStatementsFrom(cqlPath);
+
+        //then
+        String expectedStatement = "CREATE TABLE role_graphs_sql( provider text, graphml text, settings text, PRIMARY KEY (provider))";
+        assertThat(cqlStatements, hasSize(1));
+        assertThat(cqlStatements.get(0), equalToIgnoringWhiteSpace(expectedStatement));
+    }
 }

--- a/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
+++ b/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
@@ -1,0 +1,9 @@
+   -- it's role_graphs_sql table
+CREATE TABLE role_graphs_sql(
+  provider text, -- provider name
+  graphml text, ---graph markup language
+  settings text, /** xml markup language **/
+  PRIMARY KEY (provider)-- PK
+)    --
+-- EOF
+;


### PR DESCRIPTION
Current version of cqlmigrate doesn't parse *.cql files with CQL code comments (Double hypen, Forward slash asterisk). It was fixed. Please, try check