### PR TITLE
Parse cql files with code comments

### DIFF
--- a/src/main/java/uk/sky/cqlmigrate/CqlFileParser.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlFileParser.java
@@ -1,17 +1,16 @@
 package uk.sky.cqlmigrate;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Scanner;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -24,54 +23,138 @@ class CqlFileParser {
     private static final char CQL_STATEMENT_STRING_DELIMITER = '\'';
     private static final String CQL_STATEMENT_TERMINATOR = ";";
     private static final String CQL_COMMENT_DOUBLE_HYPEN = "--"; //Double hypen
-    private static final Pattern CQL_MULTI_LINE_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+    private static final String CQL_MULTI_LINE_COMMENT_OPEN = "/*"; //Forward slash asterisk
+    private static final String CQL_MULTI_LINE_COMMENT_CLOSE = "*/"; //Asterisk forward slash
+    private static final Pattern CQL_MULTI_LINE_COMMENT_PATTERN = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+    private static final Pattern EOL = Pattern.compile(".*\\R|.+\\z");
     private static final String EMPTY_STR = "";
 
     static List<String> getCqlStatementsFrom(Path cqlPath) {
-        String cqlFileAsString;
+        final LineProcessor processor = new LineProcessor();
+        String original;
 
-        try (BufferedReader cqlReader = Files.newBufferedReader(cqlPath, Charsets.UTF_8)) {
-            StringBuilder stringBuilder = new StringBuilder();
-            cqlReader.lines()
-                    .filter(line -> {
-                        final String trimmed = line.trim();
-                        return !trimmed.startsWith(CQL_COMMENT_DOUBLE_HYPEN);
-                    })
-                    .map(line -> {
-                        final int pos = line.indexOf(CQL_COMMENT_DOUBLE_HYPEN);
-                        if (pos != -1)
-                            return line.substring(0, pos);
-                        else
-                            return line;
-                    })
-                    .forEach(stringBuilder::append);
-
-            cqlFileAsString = CQL_MULTI_LINE_COMMENT.matcher(stringBuilder)
-                    .replaceAll(EMPTY_STR);
-
+        try (final Scanner in = new Scanner(cqlPath, "UTF-8")) {
+            while ((original = in.findWithinHorizon(EOL, 0)) != null) {
+                processor.process(original);
+            }
         } catch (IOException e) {
-            LOGGER.error("Failed to execute cql script {}: {}", cqlPath.getFileName(), e.getMessage());
+            LOGGER.error("Failed to process cql script {}: {}", cqlPath.getFileName(), e.getMessage());
             throw Throwables.propagate(e);
         }
 
-        checkState(cqlFileAsString.endsWith(CQL_STATEMENT_TERMINATOR), "had a non-terminated cql line: %s", cqlFileAsString);
-        return splitByStatementTerminator(cqlFileAsString);
+        processor.check();
+
+        return Arrays.asList(processor.getResult());
     }
 
-    private static List<String> splitByStatementTerminator(String cqlStatements) {
-        List<String> statementList = new ArrayList<>();
-        String candidateStatement = "";
+    static class LineProcessor {
+        private static final byte INIT = 0;
+        private static final byte FIND_EOS = 1;
+        private static final byte IS_MULTI_LINE_COMMENT = 2;
+        private static final byte IS_OPEN_STMT = 3;
+        private static final byte IS_OPEN_VALUE_EXP = 4;
+        private static final byte IS_CLOSE_STMT = 5;
 
-        for (String statementFragment : cqlStatements.split(CQL_STATEMENT_TERMINATOR)) {
-            candidateStatement += statementFragment;
-            // A semicolon preceded by an odd number of single quotes must be within a string, and therefore is not a statement terminator
-            if (CharMatcher.is(CQL_STATEMENT_STRING_DELIMITER).countIn(candidateStatement) % 2 == 0) {
-                statementList.add(candidateStatement);
-                candidateStatement = "";
-            } else {
-                candidateStatement += CQL_STATEMENT_TERMINATOR;
+        String[] statements;
+        int index;
+        byte curState = INIT;
+        StringBuilder curStmt;
+
+        void process(String original) throws IOException {
+            switch (curState) {
+                case INIT:
+                    if (statements == null) {
+                        statements = new String[1];
+                    } else {
+                        statements = Arrays.copyOf(statements, statements.length + 1);
+                        index++;
+                        statements[index] = "";
+                    }
+                    curState = FIND_EOS;
+                    curStmt = new StringBuilder();
+                    process(original);
+                    break;
+
+                case FIND_EOS:
+                case IS_OPEN_STMT:
+                    final String line = CharMatcher.WHITESPACE.trimFrom(original);
+
+                    if (line.startsWith(CQL_COMMENT_DOUBLE_HYPEN) || line.isEmpty()) {
+                        return;
+                    }
+
+                    if (line.startsWith(CQL_MULTI_LINE_COMMENT_OPEN)) {
+                        curState = IS_MULTI_LINE_COMMENT;
+                        return;
+                    }
+
+                    if (line.endsWith(CQL_STATEMENT_TERMINATOR)) {
+                        curStmt.append(" ").append(line.substring(0, line.length() - 1));
+                        statements[index] = CharMatcher.WHITESPACE.trimTrailingFrom(curStmt.toString());
+                        curState = IS_CLOSE_STMT;
+                        process(statements[index]);
+                        return;
+                    }
+
+                    // A semicolon preceded by an odd number of single quotes must be within a string,
+                    // and therefore is not a statement terminator
+                    if (CharMatcher.is(CQL_STATEMENT_STRING_DELIMITER).countIn(line) % 2 != 0) {
+                        curState = IS_OPEN_VALUE_EXP;
+                        curStmt.append(" ").append(CharMatcher.WHITESPACE.trimLeadingFrom(original));
+                        return;
+                    }
+
+                    final int pos = line.indexOf(CQL_COMMENT_DOUBLE_HYPEN);
+                    if (pos != -1) {
+                        curStmt.append(line.substring(0, pos));
+                        return;
+                    }
+
+                    final Matcher matcher = CQL_MULTI_LINE_COMMENT_PATTERN.matcher(line);
+                    if (matcher.find()) {
+                        curStmt.append(matcher.replaceAll(EMPTY_STR));
+                        return;
+                    }
+
+                    if (curState == IS_OPEN_STMT) {
+                        curStmt.append(" ").append(line);
+                    } else {
+                        curState = IS_OPEN_STMT;
+                        curStmt.append(line);
+                    }
+
+                    break;
+
+                case IS_OPEN_VALUE_EXP:
+                    if (CharMatcher.is(CQL_STATEMENT_STRING_DELIMITER).countIn(original) % 2 != 0) {
+                        curStmt.append(original);
+                        curState = FIND_EOS;
+                        return;
+                    }
+
+                    curStmt.append(original);
+
+                    break;
+
+                case IS_MULTI_LINE_COMMENT:
+                    if (CharMatcher.WHITESPACE.trimTrailingFrom(original).endsWith(CQL_MULTI_LINE_COMMENT_CLOSE))
+                        curState = FIND_EOS;
+
+                    break;
+
+                case IS_CLOSE_STMT:
+                    LOGGER.trace("CQL parsed: {}", original);
+                    curState = INIT;
+                    break;
             }
         }
-        return statementList;
+
+        private void check() {
+            checkState(curState != IS_CLOSE_STMT, "File had a non-terminated cql line");
+        }
+        
+        String[] getResult() {
+            return statements;
+        }
     }
 }

--- a/src/main/java/uk/sky/cqlmigrate/CqlFileParser.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlFileParser.java
@@ -150,7 +150,7 @@ class CqlFileParser {
         }
 
         private void check() {
-            checkState(curState != IS_CLOSE_STMT, "File had a non-terminated cql line");
+            checkState(curState == IS_CLOSE_STMT || curState == INIT, "File had a non-terminated cql line");
         }
         
         String[] getResult() {

--- a/src/main/java/uk/sky/cqlmigrate/CqlFileParser.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlFileParser.java
@@ -90,7 +90,7 @@ class CqlFileParser {
 
                     if (line.endsWith(CQL_STATEMENT_TERMINATOR)) {
                         curStmt.append(" ").append(line.substring(0, line.length() - 1));
-                        statements[index] = CharMatcher.WHITESPACE.trimTrailingFrom(curStmt.toString());
+                        statements[index] = CharMatcher.WHITESPACE.trimFrom(curStmt.toString());
                         curState = IS_CLOSE_STMT;
                         process(statements[index]);
                         return;

--- a/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class CqlFileParserTest {
 
@@ -72,4 +73,16 @@ public class CqlFileParserTest {
 
         assertEquals(cqlStatements.get(3), expectedStatement);
     }
+
+    @Test
+    public void shouldExceptionOnMissingSemicolon() throws Exception {
+        Path cqlPath = getResourcePath("cql_bootstrap_missing_semicolon/bootstrap.cql");
+        try {
+            List<String> cqlStatements = CqlFileParser.getCqlStatementsFrom(cqlPath);
+            fail();
+        } catch (IllegalStateException e) {
+            //ok
+        }
+    }
+
 }

--- a/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
@@ -67,7 +67,7 @@ public class CqlFileParserTest {
         
         assertEquals(cqlStatements.get(2), expectedStatement);
 
-        expectedStatement = "INSERT into role_graphs_sql (provider, graphml)" +
+        expectedStatement = "INSERT into role_graphs_sql (provider, graphml, settings)" +
                 " VALUES ('EARTH', '', '   the end ')";
 
         assertEquals(cqlStatements.get(3), expectedStatement);

--- a/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 public class CqlFileParserTest {
 
@@ -40,7 +39,6 @@ public class CqlFileParserTest {
 
         //when
         List<String> cqlStatements = CqlFileParser.getCqlStatementsFrom(cqlPath);
-        //cqlStatements.forEach(s -> System.out.println("CQL:" + s + "\n"));
 
         //then
         String expectedStatement;
@@ -74,15 +72,10 @@ public class CqlFileParserTest {
         assertEquals(cqlStatements.get(3), expectedStatement);
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void shouldExceptionOnMissingSemicolon() throws Exception {
         Path cqlPath = getResourcePath("cql_bootstrap_missing_semicolon/bootstrap.cql");
-        try {
-            List<String> cqlStatements = CqlFileParser.getCqlStatementsFrom(cqlPath);
-            fail();
-        } catch (IllegalStateException e) {
-            //ok
-        }
+        CqlFileParser.getCqlStatementsFrom(cqlPath);
     }
 
     @Test

--- a/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
@@ -30,4 +30,18 @@ public class CqlFileParserTest {
         assertThat(cqlStatements, hasSize(1));
         assertThat(cqlStatements.get(0), equalToIgnoringWhiteSpace(expectedStatement));
     }
+
+    @Test
+    public void shouldRemoveComments() throws Exception {
+        //given
+        Path cqlPath = getResourcePath("cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql");
+
+        //when
+        List<String> cqlStatements = CqlFileParser.getCqlStatementsFrom(cqlPath);
+
+        //then
+        String expectedStatement = "CREATE TABLE role_graphs_sql( provider text, graphml text, settings text, PRIMARY KEY (provider))";
+        assertThat(cqlStatements, hasSize(1));
+        assertThat(cqlStatements.get(0), equalToIgnoringWhiteSpace(expectedStatement));
+    }
 }

--- a/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class CqlFileParserTest {
@@ -32,16 +33,43 @@ public class CqlFileParserTest {
     }
 
     @Test
-    public void shouldRemoveComments() throws Exception {
+    public void shouldIgnoreCommentsAndNormolizeAndPreserveNewlineInValuesExp() throws Exception {
         //given
         Path cqlPath = getResourcePath("cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql");
 
         //when
         List<String> cqlStatements = CqlFileParser.getCqlStatementsFrom(cqlPath);
+        //cqlStatements.forEach(s -> System.out.println("CQL:" + s + "\n"));
 
         //then
-        String expectedStatement = "CREATE TABLE role_graphs_sql( provider text, graphml text, settings text, PRIMARY KEY (provider))";
-        assertThat(cqlStatements, hasSize(1));
+        String expectedStatement;
+        assertThat(cqlStatements, hasSize(4));
+
+        expectedStatement = "INSERT into role_graphs (provider, graphml)\n" +
+                "  VALUES ('SKY', 'some text; some more text')";
+
         assertThat(cqlStatements.get(0), equalToIgnoringWhiteSpace(expectedStatement));
+
+        expectedStatement = "CREATE TABLE role_graphs_sql(" +
+                "provider text, " +
+                "graphml text, " +
+                "settings text, " +
+                "PRIMARY KEY (provider)" +
+                ") WITH comment='test table role_graphs_sql'";
+
+        assertThat(cqlStatements.get(1), equalToIgnoringWhiteSpace(expectedStatement));
+
+        expectedStatement = "INSERT into role_graphs_sql (provider, graphml)" +
+                " VALUES ('SKY', 'some ...  \n" +
+                "-- it''s comment\n" +
+                "-- Created by yEd 3.12.2 /* <key for=\"graphml\" id=\"d0\" yfiles.type=\"resources\"/> */ <test>''</test>\n" +
+                "   the end ')";
+        
+        assertEquals(cqlStatements.get(2), expectedStatement);
+
+        expectedStatement = "INSERT into role_graphs_sql (provider, graphml)" +
+                " VALUES ('EARTH', '', '   the end ')";
+
+        assertEquals(cqlStatements.get(3), expectedStatement);
     }
 }

--- a/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlFileParserTest.java
@@ -85,4 +85,13 @@ public class CqlFileParserTest {
         }
     }
 
+    @Test
+    public void shouldCopeWithSingleLineStatement() throws Exception {
+        Path cqlPath = getResourcePath("cql_consistency_level/2016-02-12-11_30-create-table.cql");
+
+        List<String> cqlStatements = CqlFileParser.getCqlStatementsFrom(cqlPath);
+        String expectedStatement = "CREATE TABLE consistency_test (column1 text primary key, column2 text)";
+        assertThat(cqlStatements, hasSize(1));
+        assertEquals(cqlStatements.get(0), expectedStatement);
+    }
 }

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorImplTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorImplTest.java
@@ -43,7 +43,7 @@ public class CqlMigratorImplTest {
 
     @BeforeClass
     public static void setupCassandra() throws ConfigurationException, IOException, TTransportException, InterruptedException {
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE);
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, 30000);
         binaryPort = EmbeddedCassandraServerHelper.getNativeTransportPort();
 
         cluster = Cluster.builder().addContactPoints(CASSANDRA_HOSTS).withPort(binaryPort).withCredentials(username, password).build();

--- a/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
+++ b/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
@@ -1,0 +1,9 @@
+   -- it's role_graphs_sql table
+CREATE TABLE role_graphs_sql(
+  provider text, -- provider name
+  graphml text, ---graph markup language
+  settings text, /** xml markup language **/
+  PRIMARY KEY (provider)-- PK
+)    --
+-- EOF
+;

--- a/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
+++ b/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
@@ -1,9 +1,28 @@
+INSERT into role_graphs (provider, graphml)
+  VALUES ('SKY', 'some text; some more text');
+
    -- it's role_graphs_sql table
 CREATE TABLE role_graphs_sql(
   provider text, -- provider name
   graphml text, ---graph markup language
   settings text, /** xml markup language **/
   PRIMARY KEY (provider)-- PK
-)    --
+) WITH comment='test table role_graphs_sql'  --
 -- EOF
 ;
+
+INSERT into role_graphs_sql (provider, graphml)
+    VALUES ('SKY', 'some ...  
+-- it''s comment
+-- Created by yEd 3.12.2 /* <key for="graphml" id="d0" yfiles.type="resources"/> */ <test>''</test>
+   the end ')
+;
+
+/* /* Multi-line comment */
+INSERT into role_graphs_sql (provider, graphml)
+    VALUES ('EARTH', '', '<empty />');
+  */ 
+
+INSERT into role_graphs_sql (provider, graphml)
+    VALUES ('EARTH', '',
+'   the end ');

--- a/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
+++ b/src/test/resources/cql_rolegraphs_one/2015-08-16-12:05-statement-with-comments.cql
@@ -19,10 +19,10 @@ INSERT into role_graphs_sql (provider, graphml)
 ;
 
 /* /* Multi-line comment */
-INSERT into role_graphs_sql (provider, graphml)
+INSERT into role_graphs_sql (provider, graphml, settings)
     VALUES ('EARTH', '', '<empty />');
   */ 
 
-INSERT into role_graphs_sql (provider, graphml)
+INSERT into role_graphs_sql (provider, graphml, settings)
     VALUES ('EARTH', '',
 '   the end ');


### PR DESCRIPTION
CqlFileParser reimplemented (#56). We should ignore code comments, normalize queries and preserve newline in valueExpressions.