### PR TITLE
Switch dist back to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+dist: trusty
 language: java
 jdk:
-  - oraclejdk11
+  - oraclejdk8
 
 script:
   - ./gradlew clean build -Dcassandra.storagedir=/tmp/cassandra --info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: java
 jdk:
   - oraclejdk11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-dist: trusty
-language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 script:
   - ./gradlew clean build -Dcassandra.storagedir=/tmp/cassandra --info


### PR DESCRIPTION
The Travis CI builds have been failing with:
```
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```

This is because Travis CI changed the default `dist` to `Xenial` instead of `Trusty` https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment.

Xenial does not have `oraclejdk8` installed by default https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support but trusty does https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images.