### PR TITLE
Fail gracefully if lock cannot be obtained

### DIFF
--- a/src/main/java/uk/sky/cqlmigrate/CassandraLockingMechanism.java
+++ b/src/main/java/uk/sky/cqlmigrate/CassandraLockingMechanism.java
@@ -55,7 +55,7 @@ class CassandraLockingMechanism extends LockingMechanism {
      * {@inheritDoc}
      * <p>
      * Returns true if successfully inserted lock.
-     * Returns false if current lock is owned by this client.
+     * Returns true if current lock is owned by this client.
      * Returns false if WriteTimeoutException thrown.
      *
      * @throws CannotAcquireLockException if any DriverException thrown while executing queries.

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -6,6 +6,8 @@
         </encoder>
     </appender>
 
+    <logger name="org.apache.http" level="INFO" />
+
     <root level="debug">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
Perform a read on the locks before attempting to write one. Should make some failure cases around consistency more gracefully retryable. Addresses https://github.com/sky-uk/cqlmigrate/issues/87