### PR TITLE
Dh preflight checks

### DIFF
--- a/src/main/java/uk/sky/cqlmigrate/ChecksumCalculator.java
+++ b/src/main/java/uk/sky/cqlmigrate/ChecksumCalculator.java
@@ -1,0 +1,30 @@
+package uk.sky.cqlmigrate;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+class ChecksumCalculator {
+
+    static String calculateChecksum(Path path) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            final byte[] hash = digest.digest(Files.readAllBytes(path));
+            return bytesToHex(hash);
+        } catch (IOException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        final StringBuilder builder = new StringBuilder(2 * bytes.length);
+        for (byte b : bytes) {
+            final int asUnsigned = Byte.toUnsignedInt(b);
+            builder.append(Character.forDigit(asUnsigned >>> 4, 16))
+                    .append(Character.forDigit(asUnsigned & 0x0F, 16));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigrator.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigrator.java
@@ -16,20 +16,30 @@ import java.util.Collection;
  */
 
 public interface CqlMigrator {
+
+    /**
+     *
+     * See {@link CqlMigrator#migrate(String[], int, String, String, String, Collection, boolean)}
+     */
+    default void migrate(String[] hosts, int port, String username, String password, String keyspace, Collection<Path> directories) {
+        this.migrate(hosts, port, username, password, keyspace, directories, false);
+    }
+
     /**
      * If all nodes are up and a lock can be acquired this runs migration
      * starting with bootstrap.cql and then the rest in alphabetical order.
      * If the migration fails for any reason, the lock will not be released
      * and manual intervention is required to cleanup and fix the issue.
      *
-     * @param hosts       Comma separated list of cassandra hosts
-     * @param port        Native transport port for the above cassandra nodes
-     * @param username    Username for Cassandra's internal authentication using PasswordAuthenticator
-     *                    (if using AllowAllAuthenticator, can be set to any value)
-     * @param password    Password for Cassandra's internal authentication using PasswordAuthenticator
-     *                    (if using AllowAllAuthenticator, can be set to any value)
-     * @param keyspace    Keyspace name for which the schema migration needs to be applied
-     * @param directories Comma separated list of directory paths containing the cql statements for the schema change
+     * @param hosts             Comma separated list of cassandra hosts
+     * @param port              Native transport port for the above cassandra nodes
+     * @param username          Username for Cassandra's internal authentication using PasswordAuthenticator
+     *                          (if using AllowAllAuthenticator, can be set to any value)
+     * @param password          Password for Cassandra's internal authentication using PasswordAuthenticator
+     *                          (if using AllowAllAuthenticator, can be set to any value)
+     * @param keyspace          Keyspace name for which the schema migration needs to be applied
+     * @param directories       Comma separated list of directory paths containing the cql statements for the schema change
+     * @param performPrechecks  Flag showing whether to check if environment needs changes applied before obtaining lock
      * @throws ClusterUnhealthyException                           if any nodes are down or the schema is not in agreement before running migration
      * @throws CannotAcquireLockException                          if any of the queries to acquire lock fail or
      *                                                             {@link CassandraLockConfig.CassandraLockConfigBuilder#withTimeout(Duration)}
@@ -39,7 +49,15 @@ public interface CqlMigrator {
      * @throws IllegalStateException                               if cql file has changed after migration has been run
      * @throws com.datastax.driver.core.exceptions.DriverException if any of the migration queries fails
      */
-    void migrate(String[] hosts, int port, String username, String password, String keyspace, Collection<Path> directories);
+    void migrate(String[] hosts, int port, String username, String password, String keyspace, Collection<Path> directories, boolean performPrechecks);
+
+    /**
+     *
+     * See {@link CqlMigrator#migrate(Session, String, Collection, boolean)}
+     */
+    default void migrate(Session session, String keyspace, Collection<Path> directories) {
+        this.migrate(session, keyspace, directories, false);
+    }
 
     /**
      * If all nodes are up and a lock can be acquired this runs migration
@@ -47,9 +65,10 @@ public interface CqlMigrator {
      * If the migration fails for any reason, the lock will not be released
      * and manual intervention is required to cleanup and fix the issue.
      *
-     * @param session     Session to a cassandra cluster
-     * @param keyspace    Keyspace name for which the schema migration needs to be applied
-     * @param directories Comma separated list of directory paths containing the cql statements for the schema change
+     * @param session           Session to a cassandra cluster
+     * @param keyspace          Keyspace name for which the schema migration needs to be applied
+     * @param directories       Comma separated list of directory paths containing the cql statements for the schema change
+     * @param performPrechecks  Flag showing whether to check if environment needs changes applied before obtaining lock
      * @throws ClusterUnhealthyException                           if any nodes are down or the schema is not
      *                                                             in agreement before running migration
      * @throws CannotAcquireLockException                          if any of the queries to acquire lock fail or
@@ -60,7 +79,7 @@ public interface CqlMigrator {
      * @throws IllegalStateException                               if cql file has changed after migration has been run
      * @throws com.datastax.driver.core.exceptions.DriverException if any of the migration queries fails
      */
-    void migrate(Session session, String keyspace, Collection<Path> directories);
+    void migrate(Session session, String keyspace, Collection<Path> directories, boolean performPrechecks);
 
     /**
      * Drops keyspace if it exists

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
@@ -77,8 +77,10 @@ final class CqlMigratorImpl implements CqlMigrator {
         LockingMechanism lockingMechanism = cqlMigratorConfig.getCassandraLockConfig().getLockingMechanism(session, keyspace);
         LockConfig lockConfig = cqlMigratorConfig.getCassandraLockConfig();
 
+        SessionContext sessionContext = sessionContextFactory.getInstance(session, cqlMigratorConfig);
+
         if (performPrechecks) {
-            PreMigrationChecker preMigrationChecker = new PreMigrationChecker();
+            PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, keyspace);
             if (!preMigrationChecker.migrationIsNeeded()) {
                 LOGGER.info("Migration not needed as environment matches expected state");
                 return;
@@ -94,8 +96,6 @@ final class CqlMigratorImpl implements CqlMigrator {
         try {
             LOGGER.info("Loading cql files from {}", directories);
             CqlPaths paths = CqlPaths.create(directories);
-
-            SessionContext sessionContext = sessionContextFactory.getInstance(session, cqlMigratorConfig);
 
             KeyspaceBootstrapper keyspaceBootstrapper = new KeyspaceBootstrapper(sessionContext, keyspace, paths);
             SchemaUpdates schemaUpdates = new SchemaUpdates(sessionContext, keyspace);

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
@@ -79,8 +79,12 @@ final class CqlMigratorImpl implements CqlMigrator {
 
         SessionContext sessionContext = sessionContextFactory.getInstance(session, cqlMigratorConfig);
 
+        LOGGER.info("Loading cql files from {}", directories);
+        CqlPaths paths = CqlPaths.create(directories);
+
         if (performPrechecks) {
-            PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, keyspace);
+            SchemaChecker schemaChecker = new SchemaChecker(sessionContext, keyspace);
+            PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, keyspace, schemaChecker, paths);
             if (!preMigrationChecker.migrationIsNeeded()) {
                 LOGGER.info("Migration not needed as environment matches expected state");
                 return;
@@ -94,9 +98,6 @@ final class CqlMigratorImpl implements CqlMigrator {
         lock.lock();
 
         try {
-            LOGGER.info("Loading cql files from {}", directories);
-            CqlPaths paths = CqlPaths.create(directories);
-
             KeyspaceBootstrapper keyspaceBootstrapper = new KeyspaceBootstrapper(sessionContext, keyspace, paths);
             SchemaUpdates schemaUpdates = new SchemaUpdates(sessionContext, keyspace);
             SchemaLoader schemaLoader = new SchemaLoader(sessionContext, keyspace, schemaUpdates, paths);

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
@@ -79,11 +79,12 @@ final class CqlMigratorImpl implements CqlMigrator {
 
         SessionContext sessionContext = sessionContextFactory.getInstance(session, cqlMigratorConfig);
 
+        SchemaChecker schemaChecker = new SchemaChecker(sessionContext, keyspace);
+
         LOGGER.info("Loading cql files from {}", directories);
         CqlPaths paths = CqlPaths.create(directories);
 
         if (performPrechecks) {
-            SchemaChecker schemaChecker = new SchemaChecker(sessionContext, keyspace);
             PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, keyspace, schemaChecker, paths);
             if (!preMigrationChecker.migrationIsNeeded()) {
                 LOGGER.info("Migration not needed as environment matches expected state");
@@ -100,7 +101,7 @@ final class CqlMigratorImpl implements CqlMigrator {
         try {
             KeyspaceBootstrapper keyspaceBootstrapper = new KeyspaceBootstrapper(sessionContext, keyspace, paths);
             SchemaUpdates schemaUpdates = new SchemaUpdates(sessionContext, keyspace);
-            SchemaLoader schemaLoader = new SchemaLoader(sessionContext, keyspace, schemaUpdates, paths);
+            SchemaLoader schemaLoader = new SchemaLoader(sessionContext, keyspace, schemaUpdates, schemaChecker, paths);
 
             keyspaceBootstrapper.bootstrap();
             schemaUpdates.initialise();

--- a/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
@@ -1,0 +1,9 @@
+package uk.sky.cqlmigrate;
+
+public class PreMigrationChecker {
+
+    boolean migrationIsNeeded() {
+        return true;
+    }
+
+}

--- a/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
@@ -1,19 +1,31 @@
 package uk.sky.cqlmigrate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
 import static uk.sky.cqlmigrate.SchemaUpdates.SCHEMA_UPDATES_TABLE;
 
 public class PreMigrationChecker {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PreMigrationChecker.class);
 
     private final SessionContext sessionContext;
     private final String keyspace;
+    private final SchemaChecker schemaChecker;
+    private final CqlPaths paths;
 
-    public PreMigrationChecker(SessionContext sessionContext, String keyspace) {
+    public PreMigrationChecker(SessionContext sessionContext, String keyspace, SchemaChecker schemaChecker, CqlPaths paths) {
         this.sessionContext = sessionContext;
         this.keyspace = keyspace;
+        this.schemaChecker = schemaChecker;
+        this.paths = paths;
     }
 
     boolean migrationIsNeeded() {
-        return !keyspaceExists() || !schemaUpdatesTableExists();
+        return !keyspaceExists() || !schemaUpdatesTableExists() || !allMigrationFilesApplied();
     }
 
     private boolean keyspaceExists() {
@@ -24,5 +36,22 @@ public class PreMigrationChecker {
         return sessionContext.getSession().getCluster().getMetadata().getKeyspace(keyspace).getTable(SCHEMA_UPDATES_TABLE) != null;
     }
 
+    private boolean allMigrationFilesApplied() {
+        List<String> filesNotApplied = new ArrayList<>();
+        paths.applyInSortedOrder((filename, path) -> {
+            if (schemaChecker.alreadyApplied(filename)) {
+                if (schemaChecker.contentsAreDifferent(filename, path)) {
+                    LOGGER.error("Contents have changed: {}", path.getFileName());
+                    throw new IllegalStateException("Contents have changed for " + filename + " at " + path);
+                } else {
+                    LOGGER.info("Already applied: {}, skipping", path.getFileName());
+                }
+            } else {
+                filesNotApplied.add(filename);
+            }
+        });
 
+        LOGGER.info("Found {} files to be applied", filesNotApplied.size());
+        return filesNotApplied.isEmpty();
+    }
 }

--- a/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
@@ -2,8 +2,20 @@ package uk.sky.cqlmigrate;
 
 public class PreMigrationChecker {
 
+    private final SessionContext sessionContext;
+    private final String keyspace;
+
+    public PreMigrationChecker(SessionContext sessionContext, String keyspace) {
+        this.sessionContext = sessionContext;
+        this.keyspace = keyspace;
+    }
+
     boolean migrationIsNeeded() {
-        return true;
+        return !keyspaceExists();
+    }
+
+    private boolean keyspaceExists() {
+        return sessionContext.getSession().getCluster().getMetadata().getKeyspace(keyspace) != null;
     }
 
 }

--- a/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
@@ -1,5 +1,7 @@
 package uk.sky.cqlmigrate;
 
+import static uk.sky.cqlmigrate.SchemaUpdates.SCHEMA_UPDATES_TABLE;
+
 public class PreMigrationChecker {
 
     private final SessionContext sessionContext;
@@ -11,11 +13,16 @@ public class PreMigrationChecker {
     }
 
     boolean migrationIsNeeded() {
-        return !keyspaceExists();
+        return !keyspaceExists() || !schemaUpdatesTableExists();
     }
 
     private boolean keyspaceExists() {
         return sessionContext.getSession().getCluster().getMetadata().getKeyspace(keyspace) != null;
     }
+
+    private boolean schemaUpdatesTableExists() {
+        return sessionContext.getSession().getCluster().getMetadata().getKeyspace(keyspace).getTable(SCHEMA_UPDATES_TABLE) != null;
+    }
+
 
 }

--- a/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/PreMigrationChecker.java
@@ -42,7 +42,7 @@ public class PreMigrationChecker {
             if (schemaChecker.alreadyApplied(filename)) {
                 if (schemaChecker.contentsAreDifferent(filename, path)) {
                     LOGGER.error("Contents have changed: {}", path.getFileName());
-                    throw new IllegalStateException("Contents have changed for " + filename + " at " + path);
+                    throw new IllegalStateException("Pre-migration check detected that contents have changed for " + filename + " at " + path);
                 } else {
                     LOGGER.info("Already applied: {}, skipping", path.getFileName());
                 }

--- a/src/main/java/uk/sky/cqlmigrate/SchemaChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/SchemaChecker.java
@@ -1,22 +1,12 @@
 package uk.sky.cqlmigrate;
 
 import com.datastax.driver.core.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Collections;
 
 import static java.util.Objects.requireNonNull;
 
 class SchemaChecker {
     public static final String SCHEMA_UPDATES_TABLE = "schema_updates";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaChecker.class);
     private static final String CHECKSUM_COLUMN = "checksum";
 
     private final SessionContext sessionContext;
@@ -44,30 +34,10 @@ class SchemaChecker {
         String previousSha1 = row.getString(CHECKSUM_COLUMN);
 
         try {
-            String checksum = calculateChecksum(path);
+            String checksum = ChecksumCalculator.calculateChecksum(path);
             return !previousSha1.equals(checksum);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private String calculateChecksum(Path path) {
-        try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-1");
-            final byte[] hash = digest.digest(Files.readAllBytes(path));
-            return bytesToHex(hash);
-        } catch (IOException | NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static String bytesToHex(byte[] bytes) {
-        final StringBuilder builder = new StringBuilder(2 * bytes.length);
-        for (byte b : bytes) {
-            final int asUnsigned = Byte.toUnsignedInt(b);
-            builder.append(Character.forDigit(asUnsigned >>> 4, 16))
-                   .append(Character.forDigit(asUnsigned & 0x0F, 16));
-        }
-        return builder.toString();
     }
 }

--- a/src/main/java/uk/sky/cqlmigrate/SchemaChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/SchemaChecker.java
@@ -1,0 +1,73 @@
+package uk.sky.cqlmigrate;
+
+import com.datastax.driver.core.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+
+import static java.util.Objects.requireNonNull;
+
+class SchemaChecker {
+    public static final String SCHEMA_UPDATES_TABLE = "schema_updates";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaChecker.class);
+    private static final String CHECKSUM_COLUMN = "checksum";
+
+    private final SessionContext sessionContext;
+    private final String keyspace;
+
+    SchemaChecker(SessionContext sessionContext, String keyspace) {
+        this.sessionContext = sessionContext;
+        this.keyspace = keyspace;
+    }
+
+    boolean alreadyApplied(String filename) {
+        Row row = getSchemaUpdate(sessionContext.getSession(), filename);
+        return row != null;
+    }
+
+    private Row getSchemaUpdate(Session session, String filename) {
+        return session.execute(
+                new SimpleStatement("SELECT * FROM " + keyspace + "." + SCHEMA_UPDATES_TABLE + " where filename = ?", filename)
+                        .setConsistencyLevel(sessionContext.getReadConsistencyLevel()))
+                .one();
+    }
+
+    boolean contentsAreDifferent(String filename, Path path) {
+        Row row = requireNonNull(getSchemaUpdate(sessionContext.getSession(), filename));
+        String previousSha1 = row.getString(CHECKSUM_COLUMN);
+
+        try {
+            String checksum = calculateChecksum(path);
+            return !previousSha1.equals(checksum);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String calculateChecksum(Path path) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            final byte[] hash = digest.digest(Files.readAllBytes(path));
+            return bytesToHex(hash);
+        } catch (IOException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        final StringBuilder builder = new StringBuilder(2 * bytes.length);
+        for (byte b : bytes) {
+            final int asUnsigned = Byte.toUnsignedInt(b);
+            builder.append(Character.forDigit(asUnsigned >>> 4, 16))
+                   .append(Character.forDigit(asUnsigned & 0x0F, 16));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/uk/sky/cqlmigrate/SchemaLoader.java
+++ b/src/main/java/uk/sky/cqlmigrate/SchemaLoader.java
@@ -14,12 +14,15 @@ class SchemaLoader {
     private final SessionContext sessionContext;
     private final String keyspace;
     private final SchemaUpdates schemaUpdates;
+    private final SchemaChecker schemaChecker;
     private final CqlPaths paths;
 
-    SchemaLoader(SessionContext sessionContext, String keyspace, SchemaUpdates schemaUpdates, CqlPaths paths) {
+    SchemaLoader(SessionContext sessionContext, String keyspace, SchemaUpdates schemaUpdates,
+                 SchemaChecker schemaChecker, CqlPaths paths) {
         this.sessionContext = sessionContext;
         this.keyspace = keyspace;
         this.schemaUpdates = schemaUpdates;
+        this.schemaChecker = schemaChecker;
         this.paths = paths;
     }
 
@@ -31,8 +34,8 @@ class SchemaLoader {
     private class Loader implements CqlPaths.Function {
         @Override
         public void apply(String filename, Path path) {
-            if (schemaUpdates.alreadyApplied(filename)) {
-                if (schemaUpdates.contentsAreDifferent(filename, path)) {
+            if (schemaChecker.alreadyApplied(filename)) {
+                if (schemaChecker.contentsAreDifferent(filename, path)) {
                     LOGGER.error("Contents have changed: {}", path.getFileName());
                     throw new IllegalStateException("Contents have changed for " + filename + " at " + path);
                 } else {

--- a/src/main/java/uk/sky/cqlmigrate/SchemaUpdates.java
+++ b/src/main/java/uk/sky/cqlmigrate/SchemaUpdates.java
@@ -1,8 +1,5 @@
 package uk.sky.cqlmigrate;
 
-import static java.util.Objects.requireNonNull;
-
-import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
@@ -10,11 +7,7 @@ import com.datastax.driver.core.TableMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 
 class SchemaUpdates {
@@ -40,58 +33,15 @@ class SchemaUpdates {
         }
     }
 
-    boolean alreadyApplied(String filename) {
-        Row row = getSchemaUpdate(sessionContext.getSession(), filename);
-        return row != null;
-    }
-
-    private Row getSchemaUpdate(Session session, String filename) {
-        return session.execute(
-                new SimpleStatement("SELECT * FROM " + SCHEMA_UPDATES_TABLE + " where filename = ?", filename)
-                        .setConsistencyLevel(sessionContext.getReadConsistencyLevel()))
-                .one();
-    }
-
-    boolean contentsAreDifferent(String filename, Path path) {
-        Row row = requireNonNull(getSchemaUpdate(sessionContext.getSession(), filename));
-        String previousSha1 = row.getString(CHECKSUM_COLUMN);
-
-        try {
-            String checksum = calculateChecksum(path);
-            return !previousSha1.equals(checksum);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     void add(String filename, Path path) {
 
         String query = "INSERT INTO " + SCHEMA_UPDATES_TABLE + " (filename, " + CHECKSUM_COLUMN + ", applied_on)" +
                 " VALUES (?, ?, dateof(now()));";
 
-        Statement statement = new SimpleStatement(query, filename, calculateChecksum(path)).setConsistencyLevel(sessionContext.getWriteConsistencyLevel());
+        Statement statement = new SimpleStatement(query, filename, ChecksumCalculator.calculateChecksum(path)).setConsistencyLevel(sessionContext.getWriteConsistencyLevel());
 
         LOGGER.debug("Applying schema cql: {} path: {}", query, path);
         sessionContext.getSession().execute(statement);
     }
 
-    private String calculateChecksum(Path path) {
-        try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-1");
-            final byte[] hash = digest.digest(Files.readAllBytes(path));
-            return bytesToHex(hash);
-        } catch (IOException | NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static String bytesToHex(byte[] bytes) {
-        final StringBuilder builder = new StringBuilder(2 * bytes.length);
-        for (byte b : bytes) {
-            final int asUnsigned = Byte.toUnsignedInt(b);
-            builder.append(Character.forDigit(asUnsigned >>> 4, 16))
-                   .append(Character.forDigit(asUnsigned & 0x0F, 16));
-        }
-        return builder.toString();
-    }
 }

--- a/src/main/java/uk/sky/cqlmigrate/SchemaUpdates.java
+++ b/src/main/java/uk/sky/cqlmigrate/SchemaUpdates.java
@@ -18,8 +18,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 
 class SchemaUpdates {
+    public static final String SCHEMA_UPDATES_TABLE = "schema_updates";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemaUpdates.class);
-    private static final String SCHEMA_UPDATES_TABLE = "schema_updates";
     private static final String CHECKSUM_COLUMN = "checksum";
 
     private final SessionContext sessionContext;

--- a/src/test/java/uk/sky/cqlmigrate/ChecksumCalculatorTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/ChecksumCalculatorTest.java
@@ -1,0 +1,52 @@
+package uk.sky.cqlmigrate;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.sky.cqlmigrate.ChecksumCalculator.calculateChecksum;
+
+public class ChecksumCalculatorTest {
+
+    @Test
+    public void calculateChecksumThrowsWhenFileDoesNotExist() throws Exception {
+        // given
+        Path path = Paths.get("/non-existant-file.cql");
+
+        // When
+        RuntimeException runtimeException = Assertions.catchThrowableOfType(() -> calculateChecksum(path), RuntimeException.class);
+
+        // then
+        assertThat(runtimeException).isNotNull()
+                .hasCauseInstanceOf(NoSuchFileException.class);
+    }
+
+    @Test
+    public void calculateChecksumReturnsChecksumForBootstrapFile() throws Exception {
+        // given
+        Path path = Paths.get(ClassLoader.getSystemResource("cql_valid_one/bootstrap.cql").toURI());
+
+        // When
+        String checksum = calculateChecksum(path);
+
+        // then
+        assertThat(checksum).isEqualTo("1918e9ddab34fa89b2a01b777d41eb94cae8de07");
+    }
+
+    @Test
+    public void calculateChecksumReturnsChecksumForStandardCqlFile() throws Exception {
+        // given
+        Path path = Paths.get(ClassLoader.getSystemResource("cql_valid_one/2015-04-01-13:56-create-status-table.cql").toURI());
+
+        // When
+        String checksum = calculateChecksum(path);
+
+        // then
+        assertThat(checksum).isEqualTo("fa03a30eab18b64b74ee1ea7816e0513f03b4ac7");
+    }
+
+}

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
@@ -151,7 +151,7 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
 
         // ensure that any reads from schema updates are read at the configured consistency level
         queryLogs = cluster.getLogs().getQueryLogs().stream()
-                .filter(queryLog -> queryLog.getFrame().message.toString().contains("SELECT * FROM schema_updates where filename = ?"))
+                .filter(queryLog -> queryLog.getFrame().message.toString().contains("SELECT * FROM cqlmigrate_test.schema_updates where filename = ?"))
                 .filter(queryLog -> queryLog.getConsistency().equals(toSimulacronConsistencyLevel(expectedReadConsistencyLevel)))
                 .collect(Collectors.toList());
         assertThat(queryLogs.size()).isEqualTo(1);

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorImplTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorImplTest.java
@@ -210,7 +210,7 @@ public class CqlMigratorImplTest {
 
         //then
         assertThat(throwable).isNotNull();
-        assertThat(throwable.getMessage()).contains("Contents have changed for 2015-04-01-13:58-change-waste-of-space-column-to-text.cql");
+        assertThat(throwable.getMessage()).contains("Pre-migration check detected that contents have changed for 2015-04-01-13:58-change-waste-of-space-column-to-text.cql");
     }
 
     @Test

--- a/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
@@ -5,23 +5,19 @@ import com.datastax.driver.core.*;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.thrift.transport.TTransportException;
+import org.assertj.core.groups.Tuple;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.*;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +28,8 @@ public class PreMigrationCheckerIntegrationTest {
     private static Cluster cluster;
     private static Session session;
     private static ClusterHealth clusterHealth;
+
+    private static List<Tuple> allSchemaUpdates = new ArrayList<>();
 
     @BeforeClass
     public static void setupCassandra() throws ConfigurationException, IOException, TTransportException, InterruptedException {
@@ -45,6 +43,10 @@ public class PreMigrationCheckerIntegrationTest {
     @Before
     public void setUp() throws Exception {
         session.execute("DROP KEYSPACE IF EXISTS cqlmigrate_test");
+        allSchemaUpdates.clear();
+        allSchemaUpdates.add(new Tuple("2015-04-01-13:56-create-status-table.cql", "fa03a30eab18b64b74ee1ea7816e0513f03b4ac7"));
+        allSchemaUpdates.add(new Tuple("2015-04-01-13:57-add-column-to-status-table.cql", "93abe7ec3b14888b9a8bd8d680a30839a92a3248"));
+        allSchemaUpdates.add(new Tuple("2015-04-01-13:59-add-reference-data-to-status-table.cql", "75e456f43dd5e1b099091319bbf6bf047d8bc34b"));
     }
 
     @AfterClass
@@ -56,12 +58,10 @@ public class PreMigrationCheckerIntegrationTest {
     @Test
     public void migrationNotNeededIfEverythingExists() throws Exception {
         //given
-        cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
-        cluster.connect(TEST_KEYSPACE).execute("CREATE TABLE schema_updates (filename text primary key, checksum text, applied_on timestamp);");
+        createKeyspace(TEST_KEYSPACE);
+        createSchemaUpdatesTable(TEST_KEYSPACE);
+        allSchemaUpdates.forEach(t -> insertSchemaUpdate(TEST_KEYSPACE, t));
 
-        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:56-create-status-table.cql', 'fa03a30eab18b64b74ee1ea7816e0513f03b4ac7', dateof(now()));");
-        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:57-add-column-to-status-table.cql', '93abe7ec3b14888b9a8bd8d680a30839a92a3248', dateof(now()));");
-        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:59-add-reference-data-to-status-table.cql', '75e456f43dd5e1b099091319bbf6bf047d8bc34b', dateof(now()));");
         Session session = cluster.connect(TEST_KEYSPACE);
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
         SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
@@ -78,7 +78,6 @@ public class PreMigrationCheckerIntegrationTest {
     @Test
     public void migrationNeededIfKeyspaceDoesNotExist() {
         //given
-        cluster.connect("system").execute("DROP KEYSPACE IF EXISTS " + TEST_KEYSPACE + ";");
         Session session = cluster.connect("system");
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
         SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
@@ -94,7 +93,7 @@ public class PreMigrationCheckerIntegrationTest {
     @Test
     public void migrationNeededIfSchemaUpdatesTableDoesNotExist() {
         //given
-        cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+        createKeyspace(TEST_KEYSPACE);
         Session session = cluster.connect("system");
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
         SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
@@ -113,8 +112,8 @@ public class PreMigrationCheckerIntegrationTest {
         Collection<Path> cqlPaths = new ArrayList<>();
         cqlPaths.add(getResourcePath("cql_valid_one"));
 
-        cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
-        cluster.connect(TEST_KEYSPACE).execute("CREATE TABLE schema_updates (filename text primary key, checksum text, applied_on timestamp);");
+        createKeyspace(TEST_KEYSPACE);
+        createSchemaUpdatesTable(TEST_KEYSPACE);
         Session session = cluster.connect("system");
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
         SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
@@ -131,11 +130,10 @@ public class PreMigrationCheckerIntegrationTest {
     @Test
     public void shouldMigrateIfPreFlightChecksEnabledAndSomeChangesNotApplied() throws Exception {
         //given
-        cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
-        cluster.connect(TEST_KEYSPACE).execute("CREATE TABLE schema_updates (filename text primary key, checksum text, applied_on timestamp);");
+        createKeyspace(TEST_KEYSPACE);
+        createSchemaUpdatesTable(TEST_KEYSPACE);
+        allSchemaUpdates.subList(0, 2).forEach(t -> insertSchemaUpdate(TEST_KEYSPACE, t));
 
-        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:56-create-status-table.cql', 'fa03a30eab18b64b74ee1ea7816e0513f03b4ac7', dateof(now()));");
-        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:57-add-column-to-status-table.cql', '93abe7ec3b14888b9a8bd8d680a30839a92a3248', dateof(now()));");
         Session session = cluster.connect("system");
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
         SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
@@ -151,6 +149,18 @@ public class PreMigrationCheckerIntegrationTest {
 
     private Path getResourcePath(String resourcePath) throws URISyntaxException {
         return Paths.get(ClassLoader.getSystemResource(resourcePath).toURI());
+    }
+
+    private void createKeyspace(String keyspaceName) {
+        cluster.connect("system").execute("CREATE KEYSPACE " + keyspaceName + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+    }
+
+    private void createSchemaUpdatesTable(String keyspaceName) {
+        cluster.connect(keyspaceName).execute("CREATE TABLE schema_updates (filename text primary key, checksum text, applied_on timestamp);");
+    }
+
+    private void insertSchemaUpdate(String keyspaceName, Tuple filenameAndChecksum) {
+        cluster.connect(keyspaceName).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('" + filenameAndChecksum.toArray()[0] + "', '" + filenameAndChecksum.toArray()[1] + "', dateof(now()));");
     }
 
 }

--- a/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
@@ -1,0 +1,23 @@
+package uk.sky.cqlmigrate;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PreMigrationCheckerIntegrationTest {
+
+    private PreMigrationChecker preMigrationChecker;
+
+    @Before
+    public void setup() {
+        preMigrationChecker = new PreMigrationChecker();
+    }
+
+    @Test
+    public void migrationAlwaysNeeded() {
+        assertThat(preMigrationChecker.migrationIsNeeded()).isTrue();
+    }
+
+}

--- a/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
@@ -1,23 +1,77 @@
 package uk.sky.cqlmigrate;
 
 
-import org.junit.Before;
-import org.junit.Test;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Session;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.thrift.transport.TTransportException;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.*;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PreMigrationCheckerIntegrationTest {
 
-    private PreMigrationChecker preMigrationChecker;
+    private static final String TEST_KEYSPACE = "cqlmigrate_test";
+
+    private static Cluster cluster;
+    private static Session session;
+    private static ClusterHealth clusterHealth;
+
+    @BeforeClass
+    public static void setupCassandra() throws ConfigurationException, IOException, TTransportException, InterruptedException {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE);
+
+        cluster = EmbeddedCassandraServerHelper.getCluster();
+        clusterHealth = new ClusterHealth(cluster);
+        session = EmbeddedCassandraServerHelper.getSession();
+    }
 
     @Before
-    public void setup() {
-        preMigrationChecker = new PreMigrationChecker();
+    public void setUp() throws Exception {
+        session.execute("DROP KEYSPACE IF EXISTS cqlmigrate_test");
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
     }
 
     @Test
-    public void migrationAlwaysNeeded() {
-        assertThat(preMigrationChecker.migrationIsNeeded()).isTrue();
+    public void migrationNotNeededIfEverythingExists() {
+        //given
+        cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+        Session session = cluster.connect("system");
+        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
+        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE);
+
+        //when
+        boolean migrationIsNeeded = preMigrationChecker.migrationIsNeeded();
+
+        //then
+        assertThat(migrationIsNeeded).isFalse();
+    }
+
+    @Test
+    public void migrationNeededIfKeyspaceDoesNotExist() {
+        //given
+        cluster.connect("system").execute("DROP KEYSPACE IF EXISTS " + TEST_KEYSPACE + ";");
+        Session session = cluster.connect("system");
+        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
+        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE);
+
+        //when
+        boolean migrationIsNeeded = preMigrationChecker.migrationIsNeeded();
+
+        //then
+        assertThat(migrationIsNeeded).isTrue();
     }
 
 }

--- a/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
@@ -1,10 +1,7 @@
 package uk.sky.cqlmigrate;
 
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.KeyspaceMetadata;
-import com.datastax.driver.core.Session;
+import com.datastax.driver.core.*;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.thrift.transport.TTransportException;
@@ -12,7 +9,19 @@ import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.*;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,13 +54,19 @@ public class PreMigrationCheckerIntegrationTest {
     }
 
     @Test
-    public void migrationNotNeededIfEverythingExists() {
+    public void migrationNotNeededIfEverythingExists() throws Exception {
         //given
         cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
         cluster.connect(TEST_KEYSPACE).execute("CREATE TABLE schema_updates (filename text primary key, checksum text, applied_on timestamp);");
+
+        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:56-create-status-table.cql', 'fa03a30eab18b64b74ee1ea7816e0513f03b4ac7', dateof(now()));");
+        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:57-add-column-to-status-table.cql', '93abe7ec3b14888b9a8bd8d680a30839a92a3248', dateof(now()));");
+        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:59-add-reference-data-to-status-table.cql', '75e456f43dd5e1b099091319bbf6bf047d8bc34b', dateof(now()));");
         Session session = cluster.connect(TEST_KEYSPACE);
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
-        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE);
+        SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
+
+        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE, schemaChecker, CqlPaths.create(Collections.singletonList(getResourcePath("cql_valid_one"))));
 
         //when
         boolean migrationIsNeeded = preMigrationChecker.migrationIsNeeded();
@@ -66,7 +81,8 @@ public class PreMigrationCheckerIntegrationTest {
         cluster.connect("system").execute("DROP KEYSPACE IF EXISTS " + TEST_KEYSPACE + ";");
         Session session = cluster.connect("system");
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
-        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE);
+        SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
+        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE, schemaChecker, CqlPaths.create(Collections.emptyList()));
 
         //when
         boolean migrationIsNeeded = preMigrationChecker.migrationIsNeeded();
@@ -81,13 +97,60 @@ public class PreMigrationCheckerIntegrationTest {
         cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
         Session session = cluster.connect("system");
         SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
-        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE);
+        SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
+        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE, schemaChecker, CqlPaths.create(Collections.emptyList()));
 
         //when
         boolean migrationIsNeeded = preMigrationChecker.migrationIsNeeded();
 
         //then
         assertThat(migrationIsNeeded).isTrue();
+    }
+
+    @Test
+    public void shouldMigrateIfPreFlightChecksEnabledAndNoChangesApplied() throws Exception {
+        //given
+        Collection<Path> cqlPaths = new ArrayList<>();
+        cqlPaths.add(getResourcePath("cql_valid_one"));
+
+        cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+        cluster.connect(TEST_KEYSPACE).execute("CREATE TABLE schema_updates (filename text primary key, checksum text, applied_on timestamp);");
+        Session session = cluster.connect("system");
+        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
+        SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
+
+        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE, schemaChecker, CqlPaths.create(cqlPaths));
+
+        //when
+        boolean migrationIsNeeded = preMigrationChecker.migrationIsNeeded();
+
+        //then
+        assertThat(migrationIsNeeded).isTrue();
+    }
+
+    @Test
+    public void shouldMigrateIfPreFlightChecksEnabledAndSomeChangesNotApplied() throws Exception {
+        //given
+        cluster.connect("system").execute("CREATE KEYSPACE " + TEST_KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };");
+        cluster.connect(TEST_KEYSPACE).execute("CREATE TABLE schema_updates (filename text primary key, checksum text, applied_on timestamp);");
+
+        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:56-create-status-table.cql', 'fa03a30eab18b64b74ee1ea7816e0513f03b4ac7', dateof(now()));");
+        cluster.connect(TEST_KEYSPACE).execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('2015-04-01-13:57-add-column-to-status-table.cql', '93abe7ec3b14888b9a8bd8d680a30839a92a3248', dateof(now()));");
+        Session session = cluster.connect("system");
+        SessionContext sessionContext = new SessionContext(session, ConsistencyLevel.ALL, ConsistencyLevel.ALL, clusterHealth);
+        SchemaChecker schemaChecker = new SchemaChecker(sessionContext, TEST_KEYSPACE);
+
+        PreMigrationChecker preMigrationChecker = new PreMigrationChecker(sessionContext, TEST_KEYSPACE, schemaChecker, CqlPaths.create(Collections.singletonList(getResourcePath("cql_valid_one"))));
+
+        //when
+        boolean migrationIsNeeded = preMigrationChecker.migrationIsNeeded();
+
+        //then
+        assertThat(migrationIsNeeded).isTrue();
+    }
+
+    private Path getResourcePath(String resourcePath) throws URISyntaxException {
+        return Paths.get(ClassLoader.getSystemResource(resourcePath).toURI());
     }
 
 }

--- a/src/test/resources/cql_valid_two_modified_content_checksum/2015-04-01-13:58-change-waste-of-space-column-to-text.cql
+++ b/src/test/resources/cql_valid_two_modified_content_checksum/2015-04-01-13:58-change-waste-of-space-column-to-text.cql
@@ -1,0 +1,2 @@
+ALTER TABLE status DROP dependency;
+ALTER TABLE status ADD dependency text;


### PR DESCRIPTION
This pull request is to provide functionality to check whether a cql migrate should be carried out or not, before taking up resources such as locks.
It checks that the keyspace exists. If not it will migrate.
It checks that the table exists. If not it will migrate.
It checks whether the files specified have the same checksum as the files already in the database with the same names. If any of the files are missing  it will migrate.

If a row exists for a file but it has a different checksum an exception will be thrown, as before but with a clearer message.

Fixes #96 