### PR TITLE
Fix for log4j issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     testImplementation("com.google.guava:guava:25.1-jre")
-    testImplementation('org.apache.logging.log4j:log4j-core:2.15.0')
+    testImplementation('org.apache.logging.log4j:log4j-core:2.16.0')
     testImplementation('junit:junit:4.12')
     testImplementation('org.assertj:assertj-core:3.12.2')
     testImplementation('org.mockito:mockito-core:2.25.1')

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     testImplementation("com.google.guava:guava:25.1-jre")
-    testImplementation('org.apache.logging.log4j:log4j-core:2.11.2')
+    testImplementation('org.apache.logging.log4j:log4j-core:2.15.0')
     testImplementation('junit:junit:4.12')
     testImplementation('org.assertj:assertj-core:3.12.2')
     testImplementation('org.mockito:mockito-core:2.25.1')


### PR DESCRIPTION
Updated the log4j dependency to the latest version which is not affected by the exploit.