### PR TITLE
Exclude log4j dependency from runtime and compile sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ configurations {
     testCompileAndFunctional
     functional.extendsFrom(testCompileAndFunctional)
     testCompile.extendsFrom(testCompileAndFunctional)
+
+    all {
+        exclude module: 'log4j'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
As per security vulnerability, log4j will be excluded from runtime and compile scope dependencies for both main and test dependencies in cqlmigrate.