### PR TITLE
Upgrade log4j to fix CVE-2021-45105 issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     testImplementation("com.google.guava:guava:25.1-jre")
-    testImplementation('org.apache.logging.log4j:log4j-core:2.16.0')
+    testImplementation('org.apache.logging.log4j:log4j-core:2.17.0')
     testImplementation('junit:junit:4.12')
     testImplementation('org.assertj:assertj-core:3.12.2')
     testImplementation('org.mockito:mockito-core:2.25.1')


### PR DESCRIPTION
  - "Apache Log4j2 does not always protect from infinite recursion in
    lookup evaluation". See  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105