### PR TITLE
feat: Add option to postpone table check

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ CqlMigratorConfig cqlMigratorConfig = CqlMigratorConfig.builder()
         .withLockConfig(lockConfig)
         .withReadConsistencyLevel(ConsistencyLevel.LOCAL_ONE)
         .withWriteConsistencyLevel(ConsistencyLevel.ALL)
+        .withTableCheckerInitDelay(Duration.ofSeconds(5))
         .withTableCheckerTimeout(Duration.ofMinutes(1))
         .build()
 
@@ -86,6 +87,7 @@ Specify credentials, if required, using `-Dusername=<username>` and `-Dpassword=
 Specify optional properties, if required, using
 * `-Dprecheck=<true/false>` default `false` 
 * `-DtableCheckerTimeout=<duration>` default `PT1M` (This was introduced for AWS Keyspaces as when new table is created it might take time to allocate resources and if additional changes or data are inserted while table is in `CREATING` state, it will fail. If cluster is no AWS Keyspaces it will not wait.)
+* `-DtableCheckerInitDelay=<duration>` default `PT5S` (Supplement previous option as it might take time AWs Keyspaces update their system so we need to wait before we check first time.)
 * `-DreadCL` default `LOCAL_ONE`
 * `-DwriteCL` default `ALL`
 
@@ -110,7 +112,7 @@ Specify optional properties, if required, using
    /cql/2015-05-03-14:19-add-manufacturer-column.cql
    ```
 
-   Any previously applied files will be skipped. For AWS Keyspaces, it will wait after each successfully applied file for tables to get into ACTIVE state for maximum <tableCheckerTimeout> duration. 
+   Any previously applied files will be skipped. For AWS Keyspaces, it will wait after each successfully applied file for tables to get into ACTIVE state for initial <tableCheckerInitDelay> and maximum <tableCheckerTimeout> duration. 
 
 5. Releases the lock.
 

--- a/src/main/java/uk/sky/cqlmigrate/AwskTableChecker.java
+++ b/src/main/java/uk/sky/cqlmigrate/AwskTableChecker.java
@@ -15,16 +15,18 @@ class AwskTableChecker implements TableChecker {
     public static final String TABLE_ACTIVE_STATUS = "ACTIVE";
 
     private final Duration timeout;
+    private final Duration initDelay;
 
-    AwskTableChecker(Duration timeout) {
+    AwskTableChecker(Duration initDelay, Duration timeout) {
         this.timeout = timeout;
+        this.initDelay = initDelay;
     }
 
     @Override
     public void check(CqlSession session, String keyspace) {
         LOGGER.info("Waiting for tables to be provisioned");
         Awaitility.await()
-                .pollDelay(0, TimeUnit.SECONDS)
+                .pollDelay(initDelay)
                 .pollInterval(5, TimeUnit.SECONDS)
                 .atMost(timeout)
                 .until(() -> allTablesActive(session, keyspace));

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorConfig.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorConfig.java
@@ -10,12 +10,14 @@ public class CqlMigratorConfig {
     private final LockConfig cassandraLockConfig;
     private final ConsistencyLevel readConsistencyLevel;
     private final ConsistencyLevel writeConsistencyLevel;
+    private final Duration tableCheckerInitDelay;
     private final Duration tableCheckerTimeout;
 
-    private CqlMigratorConfig(LockConfig cassandraLockConfig, ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel, Duration tableCheckerTimeout) {
+    private CqlMigratorConfig(LockConfig cassandraLockConfig, ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel, Duration tableCheckerInitDelay, Duration tableCheckerTimeout) {
         this.cassandraLockConfig = requireNonNull(cassandraLockConfig);
         this.readConsistencyLevel = requireNonNull(readConsistencyLevel);
         this.writeConsistencyLevel = requireNonNull(writeConsistencyLevel);
+        this.tableCheckerInitDelay = tableCheckerInitDelay;
         this.tableCheckerTimeout = tableCheckerTimeout;
     }
 
@@ -35,6 +37,10 @@ public class CqlMigratorConfig {
         return writeConsistencyLevel;
     }
 
+    public Duration getTableCheckerInitDelay() {
+        return tableCheckerInitDelay;
+    }
+
     public Duration getTableCheckerTimeout() {
         return tableCheckerTimeout;
     }
@@ -44,6 +50,7 @@ public class CqlMigratorConfig {
         private LockConfig lockConfig;
         private ConsistencyLevel readConsistencyLevel;
         private ConsistencyLevel writeConsistencyLevel;
+        private Duration tableCheckerInitDelay = Duration.ofSeconds(5);
         private Duration tableCheckerTimeout = Duration.ofMinutes(1);
 
         private CassandraConfigBuilder() {
@@ -64,13 +71,18 @@ public class CqlMigratorConfig {
             return this;
         }
 
+        public CassandraConfigBuilder withTableCheckerInitDelay(Duration tableCheckerInitDelay) {
+            this.tableCheckerInitDelay = tableCheckerInitDelay;
+            return this;
+        }
+
         public CassandraConfigBuilder withTableCheckerTimeout(Duration tableCheckerTimeout) {
             this.tableCheckerTimeout = tableCheckerTimeout;
             return this;
         }
 
         public CqlMigratorConfig build() {
-            return new CqlMigratorConfig(lockConfig, readConsistencyLevel, writeConsistencyLevel, tableCheckerTimeout);
+            return new CqlMigratorConfig(lockConfig, readConsistencyLevel, writeConsistencyLevel, tableCheckerInitDelay, tableCheckerTimeout);
         }
     }
 }

--- a/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
+++ b/src/main/java/uk/sky/cqlmigrate/CqlMigratorImpl.java
@@ -54,6 +54,7 @@ final class CqlMigratorImpl implements CqlMigrator {
         String username = System.getProperty("username");
         String password = System.getProperty("password");
         String precheck = System.getProperty("precheck", "false");
+        Duration tableCheckerInitDelay = Duration.parse(System.getProperty("tableCheckerInitDelay", "PT5S"));
         Duration tableCheckerTimeout = Duration.parse(System.getProperty("tableCheckerTimeout", "PT1M"));
         ConsistencyLevel readCL = DefaultConsistencyLevel.valueOf(System.getProperty("readCL", "LOCAL_ONE"));
         ConsistencyLevel writeCL = DefaultConsistencyLevel.valueOf(System.getProperty("writeCL", "ALL"));
@@ -72,6 +73,7 @@ final class CqlMigratorImpl implements CqlMigrator {
                 .withLockConfig(CassandraLockConfig.builder().build())
                 .withReadConsistencyLevel(readCL)
                 .withWriteConsistencyLevel(writeCL)
+                .withTableCheckerInitDelay(tableCheckerInitDelay)
                 .withTableCheckerTimeout(tableCheckerTimeout)
                 .build();
 

--- a/src/main/java/uk/sky/cqlmigrate/TableCheckerFactory.java
+++ b/src/main/java/uk/sky/cqlmigrate/TableCheckerFactory.java
@@ -8,7 +8,7 @@ class TableCheckerFactory {
     public static final String AWSK_CLUSTER_NAME = "Amazon Keyspaces";
 
     TableChecker getInstance(CqlSession session, CqlMigratorConfig cqlMigratorConfig) {
-        return isAWSK(session) ? new AwskTableChecker(cqlMigratorConfig.getTableCheckerTimeout()) : new NoOpTableChecker();
+        return isAWSK(session) ? new AwskTableChecker(cqlMigratorConfig.getTableCheckerInitDelay(), cqlMigratorConfig.getTableCheckerTimeout()) : new NoOpTableChecker();
     }
 
     private boolean isAWSK(CqlSession session) {

--- a/src/test/java/uk/sky/cqlmigrate/AwskTableCheckerTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/AwskTableCheckerTest.java
@@ -52,7 +52,7 @@ public class AwskTableCheckerTest {
         bCluster.clearPrimes(true);
         bCluster.clearLogs();
 
-        tableChecker = new AwskTableChecker(Duration.ofSeconds(5));
+        tableChecker = new AwskTableChecker(Duration.ofSeconds(1), Duration.ofSeconds(5));
     }
 
     @AfterClass


### PR DESCRIPTION
- The check of system table if table is in ACTIVE state might need to be delay as it is not always immidiatelly updated by AWS Keyspaces