### PR TITLE
Dateof to totimestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ CqlSession session = CqlSession.builder()
         .build();
 
 // Create a migrator and run it
-CqlMigrator migrator = CqlMigratorFactory.create(lockConfig);
+CqlMigrator migrator = CqlMigratorFactory.create(cqlMigratorConfig);
 Path schemas = Paths.get(ClassLoader.getSystemResource("/cql").toURI());
 migrator.migrate(session, "my_keyspace", asList(schemas));
 ```

--- a/src/main/java/uk/sky/cqlmigrate/SchemaUpdates.java
+++ b/src/main/java/uk/sky/cqlmigrate/SchemaUpdates.java
@@ -48,7 +48,7 @@ class SchemaUpdates {
     void add(String filename, Path path) {
 
         String query = "INSERT INTO " + SCHEMA_UPDATES_TABLE + " (filename, " + CHECKSUM_COLUMN + ", applied_on)" +
-                " VALUES (?, ?, dateof(now()));";
+                " VALUES (?, ?, toTimestamp(now()));";
 
         Statement statement = SimpleStatement.newInstance(query, filename, ChecksumCalculator.calculateChecksum(path)).setConsistencyLevel(sessionContext.getWriteConsistencyLevel());
 

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
@@ -181,6 +181,7 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
                 prepareInsertQuery,
                 Lists.newArrayList(
                         com.datastax.oss.simulacron.common.codec.ConsistencyLevel.ONE,
+                        com.datastax.oss.simulacron.common.codec.ConsistencyLevel.LOCAL_ONE,
                         com.datastax.oss.simulacron.common.codec.ConsistencyLevel.ALL),
                 new LinkedHashMap<>(ImmutableMap.of("name", lockName + ".schema_migration", "client", clientId)),
                 new LinkedHashMap<>(ImmutableMap.of("name", "varchar", "client", "varchar"))))
@@ -197,6 +198,7 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
                 deleteQuery,
                 Lists.newArrayList(
                         com.datastax.oss.simulacron.common.codec.ConsistencyLevel.ONE,
+                        com.datastax.oss.simulacron.common.codec.ConsistencyLevel.LOCAL_ONE,
                         com.datastax.oss.simulacron.common.codec.ConsistencyLevel.ALL),
                 new LinkedHashMap<>(ImmutableMap.of("name", lockName + ".schema_migration", "client", clientId)),
                 new LinkedHashMap<>(ImmutableMap.of("name", "varchar", "client", "varchar"))))

--- a/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/CqlMigratorConsistencyLevelIntegrationTest.java
@@ -154,7 +154,7 @@ public class CqlMigratorConsistencyLevelIntegrationTest {
 
         //ensure that any inserts into schema updates are done at the configured consistency level
         queryLogs = cluster.getLogs().getQueryLogs().stream()
-                .filter(queryLog -> queryLog.getFrame().message.toString().contains("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES (?, ?, dateof(now()));"))
+                .filter(queryLog -> queryLog.getFrame().message.toString().contains("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES (?, ?, toTimestamp(now()));"))
                 .filter(queryLog -> queryLog.getConsistency().equals(toSimulacronConsistencyLevel(expectedWriteConsistencyLevel)))
                 .collect(Collectors.toList());
         assertThat(queryLogs.size()).isEqualTo(1);

--- a/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
+++ b/src/test/java/uk/sky/cqlmigrate/PreMigrationCheckerIntegrationTest.java
@@ -163,7 +163,7 @@ public class PreMigrationCheckerIntegrationTest {
 
     private void insertSchemaUpdate(String keyspaceName, Tuple filenameAndChecksum) {
         session.execute("USE " +keyspaceName);
-        session.execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('" + filenameAndChecksum.toArray()[0] + "', '" + filenameAndChecksum.toArray()[1] + "', dateof(now()));");
+        session.execute("INSERT INTO schema_updates (filename, checksum, applied_on) VALUES ('" + filenameAndChecksum.toArray()[0] + "', '" + filenameAndChecksum.toArray()[1] + "', toTimestamp(now()));");
     }
 
 }


### PR DESCRIPTION
Hi, `cqlmigrate` depends on the function `dateOf` in CQL which has been deprecated [at least since Cassandra 3.11](https://cassandra.apache.org/doc/3.11.11/cassandra/cql/functions.html) and probably much earlier (3.11 is the earliest documentation I could easily find, but seems it’s actually been deprecated [since 2.2](https://www.instaclustr.com/blog/5-things-you-need-to-know-about-cassandra-2-2/)).

It has been finally completely removed in 5.0.

So this PR changes all uses of `dateOf()` to `toTimestamp()` which is compatible with all versions between 2.2 and 5.0. I also changed the example snippet in README, as the `cqlMigratorConfig` object was unused there.